### PR TITLE
Automatic merging of minor and patch dependency updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,31 @@
+name: Update dependencies
+
+on:
+    schedule:
+        - cron: "00 23 * * 6"
+    workflow_dispatch:
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Using Node 14
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 14
+            - name: Update npm version to latest
+              run: npm install -g npm@latest # stop showing warnings about the lockfile
+            - name: Install dependencies
+              run: npm install
+            - name: Update to the latest minor/patch version
+              run: npx npm-check-updates -u --target minor
+            - name: Install updated dependencies & update lockfile
+              run: npm install && npm update
+            - name: Push changes
+              run: |
+                  git config --global user.name "github-actions"
+                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git diff --quiet && git diff --staged --quiet || git commit -am "$(date +%F) updated dependencies"
+                  git push

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,31 +1,31 @@
 name: Update dependencies
 
 on:
-    schedule:
-        - cron: "00 23 * * 6"
-    workflow_dispatch:
+  schedule:
+    - cron: "00 23 * * 0"
+  workflow_dispatch:
 
 jobs:
-    update:
-        runs-on: ubuntu-latest
+  update:
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v2
-            - name: Using Node 14
-              uses: actions/setup-node@v1
-              with:
-                  node-version: 14
-            - name: Update npm version to latest
-              run: npm install -g npm@latest # stop showing warnings about the lockfile
-            - name: Install dependencies
-              run: npm install
-            - name: Update to the latest minor/patch version
-              run: npx npm-check-updates -u --target minor
-            - name: Install updated dependencies & update lockfile
-              run: npm install && npm update
-            - name: Push changes
-              run: |
-                  git config --global user.name "github-actions"
-                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git diff --quiet && git diff --staged --quiet || git commit -am "$(date +%F) updated dependencies"
-                  git push
+    steps:
+      - uses: actions/checkout@v2
+      - name: Using Node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Update npm version to latest
+        run: npm install -g npm@latest # stop showing warnings about the lockfile
+      - name: Install dependencies
+        run: npm install
+      - name: Update to the latest minor/patch version
+        run: npx npm-check-updates -u --target minor
+      - name: Install updated dependencies & update lockfile
+        run: npm install && npm update
+      - name: Push changes
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git diff --quiet && git diff --staged --quiet || git commit -am "$(date +%F) updated dependencies"
+          git push


### PR DESCRIPTION
This PR brings another GitHub workflow to the roster - this one automatically applies minor and patch updates to dependencies so as we only need to review potentially breaking changes. Initially provided by [double-beep](https://github.com/double-beep) for our org, but I think it will be useful for the Election Bot given that we already have the Dependabot set.

This is an experimental PR, feel free to dismiss it if there are any concerns and please, let me know if the "at 23:00 on Sunday" schedule should be changed (Dependabot currently runs weekly on Monday 00:00 UTC)