### PR TITLE
branch for accumulating dependency updates before approving

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
-    target-branch: "master"
+    target-branch: "dependencies"
     labels:
       - "chores"
     schedule:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,31 @@
+name: Update dependencies
+
+on:
+    schedule:
+        - cron: "00 23 * * 6"
+    workflow_dispatch:
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Using Node 14
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 14
+            - name: Update npm version to latest
+              run: npm install -g npm@latest # stop showing warnings about the lockfile
+            - name: Install dependencies
+              run: npm install
+            - name: Update to the latest minor/patch version
+              run: npx npm-check-updates -u --target minor
+            - name: Install updated dependencies & update lockfile
+              run: npm install && npm update
+            - name: Push changes
+              run: |
+                  git config --global user.name "github-actions"
+                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git diff --quiet && git diff --staged --quiet || git commit -am "$(date +%F) updated dependencies"
+                  git push

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,31 +1,31 @@
 name: Update dependencies
 
 on:
-    schedule:
-        - cron: "00 23 * * 6"
-    workflow_dispatch:
+  schedule:
+    - cron: "00 23 * * 0"
+  workflow_dispatch:
 
 jobs:
-    update:
-        runs-on: ubuntu-latest
+  update:
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v2
-            - name: Using Node 14
-              uses: actions/setup-node@v1
-              with:
-                  node-version: 14
-            - name: Update npm version to latest
-              run: npm install -g npm@latest # stop showing warnings about the lockfile
-            - name: Install dependencies
-              run: npm install
-            - name: Update to the latest minor/patch version
-              run: npx npm-check-updates -u --target minor
-            - name: Install updated dependencies & update lockfile
-              run: npm install && npm update
-            - name: Push changes
-              run: |
-                  git config --global user.name "github-actions"
-                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git diff --quiet && git diff --staged --quiet || git commit -am "$(date +%F) updated dependencies"
-                  git push
+    steps:
+      - uses: actions/checkout@v2
+      - name: Using Node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Update npm version to latest
+        run: npm install -g npm@latest # stop showing warnings about the lockfile
+      - name: Install dependencies
+        run: npm install
+      - name: Update to the latest minor/patch version
+        run: npx npm-check-updates -u --target minor
+      - name: Install updated dependencies & update lockfile
+        run: npm install && npm update
+      - name: Push changes
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git diff --quiet && git diff --staged --quiet || git commit -am "$(date +%F) updated dependencies"
+          git push


### PR DESCRIPTION
@samliew I finally got some time to address the dependency install issue as we discussed `dependencies` is now the target branch for accumulating updates from Dependabot (this way I can also close Dependabot's pull requests) to be able to later merge them all in one go - I updated the `messages` branch as well, but let's merge from this one for consistency.