### PR TITLE
Another set of message builders + some utility improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
-    target-branch: "master"
+    target-branch: "dependencies"
     labels:
       - "chores"
     schedule:

--- a/src/guards.js
+++ b/src/guards.js
@@ -1,0 +1,86 @@
+/**
+ * @summary checks if the message asked why a nomination was removed
+ * @param {string} text
+ * @returns {boolean}
+ */
+const isAskedWhyNominationRemoved = (text) => {
+    const textIncludes = text.includes.bind(text);
+    const textStarts = text.startsWith.bind(text);
+
+    return ['why', 'what'].some(textStarts) &&
+        ['nomination', 'nominees', 'candidate'].some(textIncludes) &&
+        ['removed', 'withdraw', 'fewer', 'lesser', 'resign'].some(textIncludes);
+};
+
+/**
+ * @summary checks if the message asked if mods are paid
+ * @param {string} text
+ * @returns {boolean}
+ */
+const isAskedIfModsArePaid = (text) => {
+    const textIncludes = text.includes.bind(text);
+    const textStarts = text.startsWith.bind(text);
+
+    return ['why', 'what', 'are', 'how'].some(textStarts) &&
+        ['reward', 'paid', 'compensat', 'money'].some(textIncludes) &&
+        ['mods', 'moderators'].some(textIncludes);
+};
+
+/**
+ * @summary checks if the message asked how or where to vote
+ * @param {string} text
+ * @returns {boolean}
+ */
+const isAskedAboutVoting = (text) => {
+    const textIncludes = text.includes.bind(text);
+    const textStarts = text.startsWith.bind(text);
+
+    return ['where', 'how', 'want', 'when'].some(textStarts) &&
+        ['do', 'can', 'to', 'give', 'cast', 'should'].some(textIncludes) &&
+        ['voting', 'vote', 'elect'].some(textIncludes);
+};
+
+/**
+ * @summary checks if the message asked to tell candidate score
+ * @param {string} text
+ * @returns {boolean}
+ */
+const isAskedForCandidateScore = (text) => {
+    const textIncludes = text.includes.bind(text);
+
+    return text.includes('candidate score') ||
+        (['can i '].some(textIncludes) &&
+            ['be', 'become', 'nominate', 'run'].some(textIncludes) &&
+            ['mod', 'election'].some(textIncludes));
+};
+
+/**
+ * @summary checks if the message asked to tell who the current mods are
+ * @param {string} text
+ * @returns {boolean}
+ */
+const isAskedForCurrentMods = (text) => {
+    const textIncludes = text.includes.bind(text);
+    return ['who', 'current', 'mod'].every(textIncludes);
+};
+
+/**
+ * @summary checks if the message asked to tell who winners are
+ * @param {string} text
+ * @returns {boolean}
+ */
+const isAskedForCurrentWinners = (text) => {
+    const textIncludes = text.includes.bind(text);
+    const textStarts = text.startsWith.bind(text);
+
+    return ['who'].some(textStarts) && ['winners', 'new mod', 'will win', 'future mod'].some(textIncludes);
+};
+
+module.exports = {
+    isAskedWhyNominationRemoved,
+    isAskedIfModsArePaid,
+    isAskedAboutVoting,
+    isAskedForCandidateScore,
+    isAskedForCurrentMods,
+    isAskedForCurrentWinners
+};

--- a/src/index.js
+++ b/src/index.js
@@ -23,12 +23,6 @@ const { RandomArray, getRandomPlop } = require("./random.js");
 
 const {
     sayHI,
-    isAskedAboutVoting,
-    isAskedForCandidateScore,
-    isAskedIfModsArePaid,
-    isAskedWhyNominationRemoved,
-    isAskedForCurrentMods,
-    isAskedForCurrentWinners,
     sayAboutVoting,
     sayAreModsPaid,
     sayCurrentMods,
@@ -43,6 +37,15 @@ const {
     sayBadgesByType,
     sayRequiredBadges
 } = require("./messages");
+
+const {
+    isAskedAboutVoting,
+    isAskedForCandidateScore,
+    isAskedIfModsArePaid,
+    isAskedWhyNominationRemoved,
+    isAskedForCurrentMods,
+    isAskedForCurrentWinners,
+} = require("./guards");
 
 const { makeCandidateScoreCalc } = require("./score");
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,8 @@ const {
     sayElectionSchedule,
     sayOffTopicMessage,
     sayBadgesByType,
-    sayRequiredBadges
+    sayRequiredBadges,
+    sayWhatModsDo
 } = require("./messages");
 
 const {
@@ -107,6 +108,16 @@ const ignoredEventTypes = [
     34, // UserNameOrAvatarChanged
     7, 23, 24, 25, 26, 27, 28, 31, 32, 33, 35 // InternalEvents
 ];
+
+/**
+ * @typedef {{
+ *  type: "moderation"|"participation"|"editing",
+ *  name:string,
+ *  id:string,
+ *  required?: boolean
+ * }} Badge
+ * @type {Badge[]}
+ */
 const electionBadges = [
     { name: 'Deputy', required: true, type: "moderation", id: "1002" },
     { name: 'Civic Duty', required: true, type: "moderation", id: "32" },
@@ -594,8 +605,7 @@ const main = async () => {
 
             // What is a moderator/moderators do/does a mod
             else if (['what'].some(x => content.startsWith(x)) && /(are|is|do(es)?)( a)? mod(erator)?s?/.test(content)) {
-                responseText = `[Elected ♦ moderators](${election.siteUrl}/help/site-moderators) are essential to keeping the site clean, fair, and friendly. ` +
-                    `They are volunteers who are equipped to handle situations that regular users can't like enforcing the Code of Conduct, investigating and destroying sockpuppet accounts, and performing post redactions.`;
+                responseText = sayWhatModsDo(election);
             }
 
             // What are the benefits of mods

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,8 @@ const {
     sayOffTopicMessage,
     sayBadgesByType,
     sayRequiredBadges,
-    sayWhatModsDo
+    sayWhatModsDo,
+    sayCandidateScoreFormula
 } = require("./messages");
 
 const {
@@ -640,7 +641,7 @@ const main = async () => {
 
             // Candidate score formula
             else if (['how', 'what'].some(x => content.startsWith(x)) && ['candidate score', 'score calculat'].some(x => content.includes(x))) {
-                responseText = `The 40-point [candidate score](https://meta.stackexchange.com/a/252643) is calculated this way: 1 point for each 1,000 reputation up to 20,000 reputation (for 20 points); and 1 point for each of the 8 moderation, 6 participation, and 6 editing badges`;
+                responseText = sayCandidateScoreFormula(electionBadges);
             }
 
             // Stats/How many voted/participated

--- a/src/messages.js
+++ b/src/messages.js
@@ -291,84 +291,6 @@ const sayWhatModsDo = (election) => {
 
 };
 
-/**
- * @summary checks if the message asked why a nomination was removed
- * @param {string} text
- * @returns {boolean}
- */
-const isAskedWhyNominationRemoved = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['why', 'what'].some(textStarts) &&
-        ['nomination', 'nominees', 'candidate'].some(textIncludes) &&
-        ['removed', 'withdraw', 'fewer', 'lesser', 'resign'].some(textIncludes);
-};
-
-/**
- * @summary checks if the message asked if mods are paid
- * @param {string} text
- * @returns {boolean}
- */
-const isAskedIfModsArePaid = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['why', 'what', 'are', 'how'].some(textStarts) &&
-        ['reward', 'paid', 'compensat', 'money'].some(textIncludes) &&
-        ['mods', 'moderators'].some(textIncludes);
-};
-
-/**
- * @summary checks if the message asked how or where to vote
- * @param {string} text
- * @returns {boolean}
- */
-const isAskedAboutVoting = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['where', 'how', 'want', 'when'].some(textStarts) &&
-        ['do', 'can', 'to', 'give', 'cast', 'should'].some(textIncludes) &&
-        ['voting', 'vote', 'elect'].some(textIncludes);
-};
-
-/**
- * @summary checks if the message asked to tell candidate score
- * @param {string} text
- * @returns {boolean}
- */
-const isAskedForCandidateScore = (text) => {
-    const textIncludes = text.includes.bind(text);
-
-    return text.includes('candidate score') ||
-        (['can i '].some(textIncludes) &&
-            ['be', 'become', 'nominate', 'run'].some(textIncludes) &&
-            ['mod', 'election'].some(textIncludes));
-};
-
-/**
- * @summary checks if the message asked to tell who the current mods are
- * @param {string} text
- * @returns {boolean}
- */
-const isAskedForCurrentMods = (text) => {
-    const textIncludes = text.includes.bind(text);
-    return ['who', 'current', 'mod'].every(textIncludes);
-};
-
-/**
- * @summary checks if the message asked to tell who winners are
- * @param {string} text
- * @returns {boolean}
- */
-const isAskedForCurrentWinners = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['who'].some(textStarts) && ['winners', 'new mod', 'will win', 'future mod'].some(textIncludes);
-};
-
 module.exports = {
     sayHI,
     sayCurrentMods,
@@ -386,10 +308,4 @@ module.exports = {
     sayNotStartedYet,
     sayRequiredBadges,
     sayWhatModsDo,
-    isAskedWhyNominationRemoved,
-    isAskedIfModsArePaid,
-    isAskedAboutVoting,
-    isAskedForCandidateScore,
-    isAskedForCurrentMods,
-    isAskedForCurrentWinners
 };

--- a/src/messages.js
+++ b/src/messages.js
@@ -2,6 +2,10 @@ const { default: Election } = require("./Election.js");
 const { makeURL, dateToRelativetime, linkToUtcTimestamp, linkToRelativeTimestamp, pluralize, capitalize } = require("./utils.js");
 
 /**
+ * @typedef {import("./index").Badge} Badge
+ */
+
+/**
  * @summary makes bot remind users that they are here
  * @param {{ sendMessage(text:string): Promise<void> }} room //TODO: redefine
  * @param {Election} election
@@ -106,8 +110,8 @@ const sayAboutVoting = (
 
 /**
  * @summary builds a response to badges of a certain type query
- * @param {{ type: "moderation"|"participation"|"editing"|string, name:string, id:string }[]} badges
- * @param {"moderation"|"participation"|"editing"} type
+ * @param {Badge[]} badges
+ * @param {Badge["type"]} type
  * @param {boolean} [isSO]
  * @returns {string}
  */
@@ -128,7 +132,7 @@ const sayBadgesByType = (badges, type, isSO = true) => {
 /**
  * @summary builds a response to the required badges query
  * @param {Election} election
- * @param {{ required: boolean, id: string, name: string }[]} badges
+ * @param {Badge[]} badges
  * @returns {string}
  */
 const sayRequiredBadges = (election, badges) => {
@@ -273,6 +277,7 @@ const sayOffTopicMessage = (election, asked) => {
 /**
  * @summary builds an off-topic warning message
  * @param {Election} election
+ * @returns {string}
  */
 const sayWhatModsDo = (election) => {
     const { siteUrl } = election;
@@ -288,7 +293,27 @@ const sayWhatModsDo = (election) => {
     const modsDo = `They are volunteers who are equipped to handle situations regular users can't, like ${modActivities.join(", ")}`;
 
     return `${makeURL("Elected ♦ moderators", `${siteUrl}/help/site-moderators`)} are ${modsAre}. ${modsDo}.`;
+};
 
+/**
+ * @summary builds a candidate score formula message
+ * @param {Badge[]} badges
+ * @returns {string}
+ */
+const sayCandidateScoreFormula = (badges) => {
+
+    const badgeCounts = { moderation: 0, editing: 0, participation: 0 };
+
+    const numModBadges = badges.reduce((a, { type }) => {
+        a[type] += 1;
+        return a;
+    }, badgeCounts);
+
+    const counts = Object.entries(numModBadges).map(([type, count]) => `${count} ${type}`).join(", ");
+
+    const formula = `1 point for each 1,000 reputation up to 20,000 reputation (for 20 points); and 1 point for each of the ${counts} 8 moderation, 6 participation, and 6 editing badges`;
+
+    return `The 40-point ${makeURL("candidate score", "https://meta.stackexchange.com/a/252643")} is calculated this way: ${formula}`;
 };
 
 module.exports = {

--- a/src/messages.js
+++ b/src/messages.js
@@ -271,6 +271,27 @@ const sayOffTopicMessage = (election, asked) => {
 };
 
 /**
+ * @summary builds an off-topic warning message
+ * @param {Election} election
+ */
+const sayWhatModsDo = (election) => {
+    const { siteUrl } = election;
+
+    const modActivities = [
+        `enforcing the ${makeURL("Code of Conduct", `${siteUrl}/conduct`)}`,
+        `investigating and destroying sockpuppet accounts`,
+        `and performing post redactions`
+    ];
+
+    const modsAre = `essential to keeping the site clean, fair, and friendly`;
+
+    const modsDo = `They are volunteers who are equipped to handle situations regular users can't, like ${modActivities.join(", ")}`;
+
+    return `${makeURL("Elected ♦ moderators", `${siteUrl}/help/site-moderators`)} are ${modsAre}. ${modsDo}.`;
+
+};
+
+/**
  * @summary checks if the message asked why a nomination was removed
  * @param {string} text
  * @returns {boolean}
@@ -364,6 +385,7 @@ module.exports = {
     sayMissingBadges,
     sayNotStartedYet,
     sayRequiredBadges,
+    sayWhatModsDo,
     isAskedWhyNominationRemoved,
     isAskedIfModsArePaid,
     isAskedAboutVoting,

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,5 +1,5 @@
 const { default: Election } = require("./Election.js");
-const { makeURL, dateToRelativetime, linkToUtcTimestamp, linkToRelativeTimestamp, pluralize, capitalize } = require("./utils.js");
+const { makeURL, dateToRelativetime, linkToUtcTimestamp, linkToRelativeTimestamp, pluralize, capitalize, listify } = require("./utils.js");
 
 /**
  * @typedef {import("./index").Badge} Badge
@@ -309,11 +309,21 @@ const sayCandidateScoreFormula = (badges) => {
         return a;
     }, badgeCounts);
 
-    const counts = Object.entries(numModBadges).map(([type, count]) => `${count} ${type}`).join(", ");
+    const counts = Object.entries(numModBadges).map(([type, count]) => `${count} ${type}`);
 
-    const formula = `1 point for each 1,000 reputation up to 20,000 reputation (for 20 points); and 1 point for each of the ${counts} 8 moderation, 6 participation, and 6 editing badges`;
+    const badgeSum = Object.values(numModBadges).reduce((a, c) => a + c);
 
-    return `The 40-point ${makeURL("candidate score", "https://meta.stackexchange.com/a/252643")} is calculated this way: ${formula}`;
+    const maxRepPts = 20;
+
+    const allPts = badgeSum + maxRepPts;
+
+    const repPts = `1 point for each 1,000 reputation up to 20,000 reputation (${maxRepPts} point${pluralize(badgeSum)})`;
+
+    const badgePts = `and 1 point for each of the ${listify(...counts)} badges (${badgeSum} point${pluralize(badgeSum)})`;
+
+    const formula = `${repPts}; ${badgePts}`;
+
+    return `The ${allPts}-point ${makeURL("candidate score", "https://meta.stackexchange.com/a/252643")} is calculated this way: ${formula}`;
 };
 
 module.exports = {
@@ -333,4 +343,5 @@ module.exports = {
     sayNotStartedYet,
     sayRequiredBadges,
     sayWhatModsDo,
+    sayCandidateScoreFormula
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,6 +109,13 @@ const capitalize = (word) => word[0].toUpperCase() + word.slice(1).toLowerCase()
 const pluralize = (amount, pluralSuffix = "s", singularSuffix = "") => amount !== 1 ? pluralSuffix : singularSuffix;
 
 /**
+ * @summary turns list of items into a enumeration
+ * @param {...string} items
+ * @returns {string}
+ */
+const listify = (...items) => items.length > 2 ? `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}` : items.join(", ");
+
+/**
  * @summary validates and normalizes the Date
  * @param {Date|number|string} input
  * @returns {Date}
@@ -286,6 +293,7 @@ module.exports = {
     makeURL,
     capitalize,
     pluralize,
+    listify,
     link,
     apiBase,
     apiVer

--- a/test/messages.js
+++ b/test/messages.js
@@ -32,6 +32,8 @@ describe("Messages module", () => {
     });
 
     describe('sayBadgesByType', () => {
+
+        /** @type {import("../src").Badge[]} */
         const badges = [{
             id: "1", name: "Badge1", type: "moderation"
         },

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { listify, pluralize } from "../src/utils";
+
+describe('String-related utils', () => {
+
+    describe('listify', () => {
+
+        it('should join with a comma if <= 2 items', () => {
+            const list = listify("first", "second");
+            expect(list).to.equal("first, second");
+        });
+
+        it('should join last item with ", and <item>" if > 2 items', () => {
+            const list = listify("alpha", "beta", "gamma");
+            expect(list).to.equal("alpha, beta, and gamma");
+        });
+
+    });
+
+    describe('pluralize', () => {
+
+        it('should not pluralize item count === 1', () => {
+            const plural = pluralize(1, "s");
+            expect(plural).to.equal("");
+        });
+
+        it('should pluralize otherwise', () => {
+            const plural = pluralize(10, "es");
+            expect(plural).to.equal("es");
+        });
+
+    });
+
+});


### PR DESCRIPTION
As promised, this PR adds:

- even more dedicated message builders
- splits builders and guards in 2 modules for maintainability
- adds a new utility and tests for it (for making `one, ..., N-1, and N` lists out of arrays)
- moves `@typedef` for `Badge` type to index (and reconnects it everywhere) for maintainability

On an off-note, @samliew - is it possible to unfreeze the dev chat room and start the bot up as it will probably take a long time to cover everything with unit tests, not to mention the integration tests, as well as E2E ones. If that eats at your Heroku hours quotas, I can spawn the bot myself, but have to ask for green light first :)