### PR TITLE
Changes, fixes, and updates based on live testing

### DIFF
--- a/patches/chatexchange+0.3.0.patch
+++ b/patches/chatexchange+0.3.0.patch
@@ -11,3 +11,104 @@ index 98c1435..5566a1f 100644
      id: number;
      name: string;
      about: string;
+diff --git a/node_modules/chatexchange/dist/Browser.js b/node_modules/chatexchange/dist/Browser.js
+index d4fad6c..35c2dcb 100644
+--- a/node_modules/chatexchange/dist/Browser.js
++++ b/node_modules/chatexchange/dist/Browser.js
+@@ -170,13 +170,13 @@ class Browser {
+         // Filter out only text (Ignore HTML entirely)
+         const statsElements = $(".user-keycell,.user-valuecell")
+             .map((_i, el) => $(el)
+-            .text()
+-            .trim()
+-            .replace(/\s{2,}[\w\s()]*/u, ""))
++                .text()
++                .trim()
++                .replace(/\s{2,}[\w\s()]*/u, ""))
+             .toArray();
+         const { about, "last message": lmsg, "last seen": lseen,
+-        //@ts-expect-error
+-         } = utils_1.arrayToKvp(statsElements);
++            //@ts-expect-error
++        } = utils_1.arrayToKvp(statsElements);
+         if (typeof lmsg !== "undefined") {
+             lastMessage = utils_1.parseAgoString(lmsg);
+         }
+@@ -215,6 +215,14 @@ class Browser {
+         if (replyInfo.length > 0) {
+             parentMessageId = parseInt(replyInfo.attr("href").split("#")[1], 10);
+         }
++
++        const $userDiv = $msg.parent().prev(".signature").find(".username a");
++
++        const userId = parseInt($userDiv.attr("href").split("/")[2], 10);
++        const userName = $userDiv.text();
++
++        const user = this._client.getUser(userId, { name: userName });
++
+         return {
+             content,
+             edited,
+@@ -222,6 +230,9 @@ class Browser {
+             parentMessageId,
+             roomId,
+             roomName,
++            user,
++            userId,
++            userName
+         };
+     }
+     /**
+diff --git a/node_modules/chatexchange/dist/Message.js b/node_modules/chatexchange/dist/Message.js
+index f112fc8..eca19c6 100644
+--- a/node_modules/chatexchange/dist/Message.js
++++ b/node_modules/chatexchange/dist/Message.js
+@@ -33,29 +33,30 @@ class Message {
+         return utils_1.lazy(() => this._room, () => this._setRoom());
+     }
+     get roomId() {
+-        return utils_1.lazy(() => this._roomId, () => this._scrapeTranscript());
++        return utils_1.lazy(() => this._roomId, () => this._scrapeTranscript("roomId"));
+     }
+     get content() {
+-        return utils_1.lazy(() => this._content, () => this._scrapeTranscript());
++        return utils_1.lazy(() => this._content, () => this._scrapeTranscript("content"));
+     }
+     get userId() {
+-        return utils_1.lazy(() => this._userId, () => this._scrapeTranscript());
++        return utils_1.lazy(() => this._userId, () => this._scrapeTranscript("userId"));
+     }
+     get targetUserId() {
+-        return utils_1.lazy(() => this._targetUserId, () => this._scrapeTranscript());
++        return utils_1.lazy(() => this._targetUserId, () => this._scrapeTranscript("targetUserId"));
+     }
+     get parentId() {
+-        return utils_1.lazy(() => this._parentId, () => this._scrapeTranscript());
++        return utils_1.lazy(() => this._parentId, () => this._scrapeTranscript("parentMessageId"));
+     }
+     async _setRoom() {
+         const roomId = await this.roomId;
+         this._room = this._client.getRoom(roomId);
+     }
+-    async _scrapeTranscript() {
++    async _scrapeTranscript(prop) {
+         const data = await this._client._browser.getTranscript(this.id);
+         for (const [key, value] of Object.entries(data)) {
+             this[`_${key}`] = value;
+         }
++        return data[prop];
+     }
+     /**
+      * Send a reply to this message, replying to the user
+diff --git a/node_modules/chatexchange/dist/Room.js b/node_modules/chatexchange/dist/Room.js
+index 9ced9be..814b99b 100644
+--- a/node_modules/chatexchange/dist/Room.js
++++ b/node_modules/chatexchange/dist/Room.js
+@@ -61,6 +61,7 @@ class Room extends events_1.EventEmitter {
+                 const msg = new Message_1.default(this._client, event.message_id, {
+                     room: this,
+                     roomId: this.id,
++                    ...event
+                 });
+                 this.emit("message", msg);
+             }

--- a/src/Election.js
+++ b/src/Election.js
@@ -159,6 +159,8 @@ export default class Election {
             this.repVote = 150;
             this.repNominate = repToNominate;
 
+            //clear an array before rescraping
+            this.arrNominees.length = 0;
             this.arrNominees.push(...nominees);
 
             this.qnaUrl = process.env.ELECTION_QA_URL || electionPost.find('a[href*="/questions/tagged/election"]').attr('href');

--- a/src/Election.js
+++ b/src/Election.js
@@ -47,21 +47,18 @@ export default class Election {
      *
      * @static
      * @summary gets current phase given election dates
-     * @param {string} nominationDate
-     * @param {string} startDate
-     * @param {string} primaryDate
-     * @param {string} endDate
+     * @param {Election} election
      * @returns {ElectionPhase}
      */
-    static getPhase(nominationDate, startDate, primaryDate, endDate, today = new Date()) {
+    static getPhase({ dateNomination, dateElection, datePrimary, dateEnded }, today = new Date()) {
         const now = today.valueOf();
 
         /** @type {[string, ElectionPhase][]} */
         const phaseMap = [
-            [endDate, "ended"],
-            [startDate, "election"],
-            [primaryDate, "primary"],
-            [nominationDate, "nomination"]
+            [dateEnded, "ended"],
+            [dateElection, "election"],
+            [datePrimary, "primary"],
+            [dateNomination, "nomination"]
         ];
 
         const [, phase = null] = phaseMap.find(([d]) => !!d && new Date(d).valueOf() <= now) || [];
@@ -166,7 +163,7 @@ export default class Election {
             this.qnaUrl = process.env.ELECTION_QA_URL || electionPost.find('a[href*="/questions/tagged/election"]').attr('href');
             this.chatUrl = process.env.ELECTION_CHATROOM_URL || electionPost.find('a[href*="/rooms/"]').attr('href');
 
-            this.phase = Election.getPhase(nominationDate, startDate, primaryDate, endDate);
+            this.phase = Election.getPhase(this);
 
             // If election has ended (or cancelled)
             if (this.phase === 'ended') {

--- a/src/Election.js
+++ b/src/Election.js
@@ -63,6 +63,12 @@ export default class Election {
 
             const electionPost = $('#mainbar .js-post-body .wiki-ph');
 
+            const conditionsNotice = $($('#mainbar').find('aside[role=status]').get(0));
+
+            const [, minRep = "0"] = /with (?:more than )?(\d+,?\d+) reputation/m.exec(conditionsNotice.text()) || [];
+
+            const repToNominate = +minRep.replace(/\D/g, "");
+
             this.updated = Date.now();
             this.sitename = $('meta[property="og:site_name"]').attr('content').replace('Stack Exchange', '').trim();
             this.siteHostname = this.electionUrl.split('/')[2]; // hostname only, exclude trailing slash
@@ -75,7 +81,7 @@ export default class Election {
             this.numCandidates = +numCandidates;
             this.numPositions = +numPositions;
             this.repVote = 150;
-            this.repNominate = Number($('#sidebar .s-sidebarwidget--content b').eq(1).text().replace(/\D+/g, ''));
+            this.repNominate = repToNominate;
             this.arrWinners = [];
             this.arrNominees = $('#mainbar .candidate-row').map((i, el) => {
                 return {

--- a/src/Election.js
+++ b/src/Election.js
@@ -54,7 +54,12 @@ export default class Election {
             const metaElems = content.find(".flex--item.mt4 .d-flex.gs4 .flex--item:nth-child(2)");
             const metaVals = metaElems.map((_i, el) => $(el).attr('title') || $(el).text()).get();
 
-            const [nominationDate, startDate, endDate, numCandidates, numPositions] = metaVals;
+            const [numCandidates, numPositions] = metaVals.slice(-2, metaVals.length);
+
+            // Insert null value in second position for elections with no primary phase
+            if (metaVals.length === 5) metaVals.splice(1, 0, null);
+
+            const [nominationDate, primaryDate, startDate, endDate] = metaVals;
 
             const electionPost = $('#mainbar .js-post-body .wiki-ph');
 
@@ -64,7 +69,7 @@ export default class Election {
             this.siteUrl = 'https://' + this.siteHostname;
             this.title = $('#content h1').first().text().trim();
             this.dateNomination = nominationDate;
-            this.datePrimary = null; //sidebarValues[1]; //TODO where's primary in the new UI?
+            this.datePrimary = primaryDate;
             this.dateElection = startDate;
             this.dateEnded = endDate;
             this.numCandidates = +numCandidates;

--- a/src/Election.js
+++ b/src/Election.js
@@ -3,15 +3,16 @@ const utils = require('./utils');
 
 export default class Election {
 
+    /**
+     * @param {string} electionUrl URL of the election, i.e. https://stackoverflow.com/election/12
+     * @param {string|number} [electionNum] number of election, can be a numeric string
+     */
     constructor(electionUrl, electionNum = null) {
         this.electionUrl = electionUrl;
 
-        if (electionNum) {
-            this.electionNum = Number(electionNum);
-        }
-        else {
-            this.electionNum = Number(electionUrl.split('/').pop()) || null;
-        }
+        this.electionNum = electionNum ?
+            +electionNum :
+            +electionUrl.split('/').pop() || null;
 
         // private
         this._prevObj = null;

--- a/src/Election.js
+++ b/src/Election.js
@@ -69,6 +69,8 @@ export default class Election {
 
             const repToNominate = +minRep.replace(/\D/g, "");
 
+            const candidateElems = $('#mainbar .candidate-row');
+
             this.updated = Date.now();
             this.sitename = $('meta[property="og:site_name"]').attr('content').replace('Stack Exchange', '').trim();
             this.siteHostname = this.electionUrl.split('/')[2]; // hostname only, exclude trailing slash
@@ -83,15 +85,17 @@ export default class Election {
             this.repVote = 150;
             this.repNominate = repToNominate;
             this.arrWinners = [];
-            this.arrNominees = $('#mainbar .candidate-row').map((i, el) => {
+            this.arrNominees = candidateElems.map((_i, el) => {
+                const userLink = $(el).find('.user-details a');
+
                 return {
-                    userId: Number($(el).find('.user-details a').attr('href').split('/')[2]),
-                    userName: $(el).find('.user-details a').text(),
-                    userYears: $(el).find('.user-details').contents().map(function () {
-                        if (this.type === 'text') return this.data.trim();
-                    }).get().join(' ').trim(),
+                    userId: +(userLink.attr('href').split('/')[2]),
+                    userName: userLink.text(),
+                    userYears: $(el).find('.user-details').contents().map((_i, { data, type }) =>
+                        type === 'text' ? data.trim() : ""
+                    ).get().join(' ').trim(),
                     userScore: $(el).find('.candidate-score-breakdown').find('b').text().match(/(\d+)\/\d+$/)[0],
-                    permalink: electionPageUrl + '#' + $(el).attr('id'),
+                    permalink: `${electionPageUrl}#${$(el).attr('id')}`,
                 };
             }).get();
 
@@ -131,9 +135,9 @@ export default class Election {
                 // Election ended
                 else {
                     // Get election stats
-                    this.statVoters = $(statsElem).contents().map((_i, { data, type }) => {
-                        if (type === 'text') return data.trim();
-                    }).get().join(' ').trim();
+                    this.statVoters = $(statsElem).contents().map((_i, { data, type }) =>
+                        type === 'text' ? data.trim() : ""
+                    ).get().join(' ').trim();
 
                     // Get winners
                     let winners = $(statsElem).find('a').map((_i, el) => +($(el).attr('href').split('/')[2])).get();

--- a/src/Election.js
+++ b/src/Election.js
@@ -53,8 +53,8 @@ export default class Election {
      * @param {string} endDate
      * @returns {ElectionPhase}
      */
-    static getPhase(nominationDate, startDate, primaryDate, endDate) {
-        const now = Date.now();
+    static getPhase(nominationDate, startDate, primaryDate, endDate, today = new Date()) {
+        const now = today.valueOf();
 
         /** @type {[string, ElectionPhase][]} */
         const phaseMap = [
@@ -64,7 +64,7 @@ export default class Election {
             [nominationDate, "nomination"]
         ];
 
-        const [, phase = null] = phaseMap.find(([datestr]) => new Date(datestr).valueOf() <= now) || [];
+        const [, phase = null] = phaseMap.find(([d]) => !!d && new Date(d).valueOf() <= now) || [];
 
         return phase;
     }

--- a/src/ScheduledAnnouncement.js
+++ b/src/ScheduledAnnouncement.js
@@ -6,13 +6,13 @@ export default class ScheduledAnnouncement {
     constructor(room, election) {
         this._room = room;
         this._election = election;
-    
+
         // Run the sub-functions once only
         this._nominationSchedule = null;
         this._primarySchedule = null;
         this._electionSchedule = null;
         this._winnerSchedule = null;
-        
+
         // Store task so we can stop if needed
         this._nominationTask = null;
         this._primaryTask = null;
@@ -30,7 +30,7 @@ export default class ScheduledAnnouncement {
             primary: this._primarySchedule,
             election: this._electionSchedule,
             ended: this._winnerSchedule
-        }
+        };
     }
 
     setRoom(room) {
@@ -40,12 +40,12 @@ export default class ScheduledAnnouncement {
     setElection(election) {
         this._election = election;
     }
-    
+
     initWinner(date) {
-        if(this._winnerSchedule != null || this._winnerTask != null) return false;
+        if (this._winnerSchedule != null || this._winnerTask != null) return false;
 
         const _endedDate = new Date(date);
-        if(_endedDate > Date.now()) {
+        if (_endedDate.valueOf() > Date.now()) {
             const cs = `0 ${_endedDate.getHours()} ${_endedDate.getDate()} ${_endedDate.getMonth() + 1} *`;
             this._winnerTask = cron.schedule(
                 cs,
@@ -61,10 +61,10 @@ export default class ScheduledAnnouncement {
     }
 
     initElection(date) {
-        if(this._electionSchedule != null || this._electionTask != null || typeof date == 'undefined') return false;
+        if (this._electionSchedule != null || this._electionTask != null || typeof date == 'undefined') return false;
 
         const _electionDate = new Date(date);
-        if(_electionDate > Date.now()) {
+        if (_electionDate.valueOf() > Date.now()) {
             const cs = `0 ${_electionDate.getHours()} ${_electionDate.getDate()} ${_electionDate.getMonth() + 1} *`;
             this._electionTask = cron.schedule(
                 cs,
@@ -80,10 +80,10 @@ export default class ScheduledAnnouncement {
     }
 
     initPrimary(date) {
-        if(this._primarySchedule != null || this._primaryTask != null || typeof date == 'undefined') return false;
+        if (this._primarySchedule != null || this._primaryTask != null || typeof date == 'undefined') return false;
 
         const _primaryDate = new Date(date);
-        if(_primaryDate > Date.now()) {
+        if (_primaryDate.valueOf() > Date.now()) {
             const cs = `0 ${_primaryDate.getHours()} ${_primaryDate.getDate()} ${_primaryDate.getMonth() + 1} *`;
             this._primaryTask = cron.schedule(
                 cs,
@@ -99,10 +99,10 @@ export default class ScheduledAnnouncement {
     }
 
     initNomination(date) {
-        if(this._nominationSchedule != null || this._nominationTask != null || typeof date == 'undefined') return false;
+        if (this._nominationSchedule != null || this._nominationTask != null || typeof date == 'undefined') return false;
 
         const _nominationDate = new Date(date);
-        if(_nominationDate > Date.now()) {
+        if (_nominationDate.valueOf() > Date.now()) {
             const cs = `0 ${_nominationDate.getHours()} ${_nominationDate.getDate()} ${_nominationDate.getMonth() + 1} *`;
             this._nominationTask = cron.schedule(
                 cs,
@@ -126,7 +126,7 @@ export default class ScheduledAnnouncement {
             async () => {
                 console.log('TEST CRON STARTED');
                 await this._election.scrapeElection();
-                await this._room.sendMessage(`Test cron job succesfully completed at ${utils.dateToTimestamp(this._election.updated)}.`);
+                await this._room.sendMessage(`Test cron job succesfully completed at ${utils.dateToUtcTimestamp(this._election.updated)}.`);
                 console.log('TEST CRON ENDED', this._election, '\n', this._room);
             },
             { timezone: "Etc/UTC" }
@@ -142,11 +142,11 @@ export default class ScheduledAnnouncement {
     }
 
     cancelAll() {
-        if(this._nominationTask != null) this._nominationTask.stop();
-        if(this._primaryTask != null) this._primaryTask.stop();
-        if(this._electionTask != null) this._electionTask.stop();
-        if(this._winnerTask != null) this._winnerTask.stop();
-        
+        if (this._nominationTask != null) this._nominationTask.stop();
+        if (this._primaryTask != null) this._primaryTask.stop();
+        if (this._electionTask != null) this._electionTask.stop();
+        if (this._winnerTask != null) this._winnerTask.stop();
+
         this._nominationSchedule = null;
         this._primarySchedule = null;
         this._electionSchedule = null;

--- a/src/api.js
+++ b/src/api.js
@@ -1,16 +1,16 @@
 const { apiBase, apiVer, fetchUrl } = require("./utils.js");
 
 /**
- * @typedef {import("./utils.js").APIListResponse} APIListResponse
- * @typedef {import("./utils.js").ResItem} ResItem
+ * @typedef {import("./utils.js").BadgeItem} BadgeItem
  *
  * @summary gets badges from the API
  * @param {import("chatexchange/dist/Browser").IProfileData} user user to request badges for
  * @param {string} site election site slug
  * @param {string} key api key
- * @returns {Promise<ResItem[]>}
+ * @param {number} [page]
+ * @returns {Promise<BadgeItem[]>}
  */
-const getBadges = async (user, site, key) => {
+const getBadges = async (user, site, key, page = 1) => {
     const { id } = user;
 
     const badgeURI = new URL(`${apiBase}/${apiVer}/users/${id}/badges`);
@@ -19,11 +19,16 @@ const getBadges = async (user, site, key) => {
         order: "asc",
         sort: "type",
         pagesize: "100",
-        filter: "!SWJuQzAN)_Pb81O3B)",
+        filter: "7W_5Hvzzo",
         key
     }).toString();
 
-    const { items = [] } = /**@type {APIListResponse} */(await fetchUrl(badgeURI.toString(), true)) || {};
+    const { items = [], has_more } = /**@type {{ items: BadgeItem[], has_more: boolean }} */(await fetchUrl(badgeURI.toString(), true)) || {};
+
+    if (has_more) {
+        const otherItems = await getBadges(user, site, key, page + 1);
+        return [...items, ...otherItems];
+    }
 
     return items;
 };

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,0 +1,125 @@
+export class Command {
+
+    /** @type {Command} */
+    aliasFor = null;
+
+    /** @type {Command[]} */
+    aliases = [];
+
+    /**
+     * @param {string} name
+     * @param {string} description
+     * @param {(...args:any[]) => unknown} handler
+     */
+    constructor(name, description, handler) {
+        this.name = name;
+        this.description = description;
+        this.handler = handler;
+    }
+
+    /**
+     * @summary runs the command
+     * @param {...any[]} args
+     */
+    run(...args) {
+        return this.handler.apply(this, args);
+    }
+
+    /**
+     * @summary makes a copy of a command
+     * @param {Command} command
+     * @param {string} [newName]
+     */
+    static fromCommand(command, newName) {
+        const { name, description, handler } = command;
+        return new Command(newName || name, description, handler);
+    }
+}
+
+export class CommandManager {
+
+    /**@type {{ [name:string]: Command }} */
+    commands = {};
+
+    /**
+     * @summary adds a command to manager
+     * @param {string} name
+     * @param {string} description
+     * @param {(...args:any[]) => unknown} handler
+     */
+    add(name, description, handler) {
+        this.commands[name] = new Command(name, description, handler);
+    }
+
+    /**
+     * @summary aliases a command
+     * @param {string} name
+     * @param {string[]} aliases
+     */
+    alias(name, aliases) {
+        const { commands } = this;
+        const command = commands[name];
+        if (!command) throw new Error(`missing command: ${name}`);
+        aliases.forEach((alias) => {
+            const copy = Command.fromCommand(command, alias);
+            copy.aliasFor = command;
+            command.aliases.push(copy);
+            commands[alias] = copy;
+        });
+    }
+
+    /**
+     * @summary runs a command by name
+     * @param {string} name
+     * @param {...any} args
+     */
+    run(name, ...args) {
+        const command = this.commands[name];
+        return command?.run(...args);
+    }
+
+    /**
+     * @summary gets a command that matches a regular expression
+     * @param {RegExp} regex
+     * @returns {Command}
+     */
+    getMatching(regex) {
+        const { commands } = this;
+        const [, command] = Object.entries(commands).find(([name]) => regex.test(name)) || [];
+        return command;
+    }
+
+    /**
+     * @summary runs a command that matches a regular expression
+     * @param {RegExp} regex
+     * @param {...any} args
+     */
+    runMatching(regex, ...args) {
+        return this.getMatching(regex)?.run(...args);
+    }
+
+    /**
+     * @param {string} text
+     * @param {string} name
+     * @param {RegExp} regex
+     */
+    runIfMatches(text, name, regex, ...args) {
+        return regex.test(text) && this.commands[name]?.run(...args);
+    }
+
+    /**
+     * @summary lists commands and usage
+     */
+    help(prefix = "Commands") {
+        const { commands } = this;
+        const list = Object.values(commands)
+            .filter(({ aliasFor }) => !aliasFor)
+            .map(({ name, description, aliases }) => {
+                const aliasNames = aliases.map(({ name }) => name).join(", ");
+                const alias = aliasNames ? ` (${aliasNames})` : "";
+                return `- [${name}]${alias} ${description}`;
+            }).join("\n");
+
+        return `${prefix}\n${list}`;
+    }
+}

--- a/src/guards.js
+++ b/src/guards.js
@@ -4,12 +4,9 @@
  * @returns {boolean}
  */
 const isAskedWhyNominationRemoved = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['why', 'what'].some(textStarts) &&
-        ['nomination', 'nominees', 'candidate'].some(textIncludes) &&
-        ['removed', 'withdraw', 'fewer', 'lesser', 'resign'].some(textIncludes);
+    return /^(?:why|what)\b/.test(text) &&
+        /\b(?:nomination|nominees|candidate)\b/.test(text) &&
+        /\b(?:removed|withdraw|fewer|lesser|resign)\b/.test(text);
 };
 
 /**
@@ -18,12 +15,9 @@ const isAskedWhyNominationRemoved = (text) => {
  * @returns {boolean}
  */
 const isAskedIfModsArePaid = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['why', 'what', 'are', 'how'].some(textStarts) &&
-        ['reward', 'paid', 'compensat', 'money'].some(textIncludes) &&
-        ['mods', 'moderators'].some(textIncludes);
+    return /^(?:why|what|are|how)\b/.test(text) &&
+        /\b(?:reward|paid|compensated|money)\b/.test(text) &&
+        /\b(?:mods|moderators)\b/.test(text);
 };
 
 /**
@@ -32,12 +26,9 @@ const isAskedIfModsArePaid = (text) => {
  * @returns {boolean}
  */
 const isAskedAboutVoting = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['where', 'how', 'want', 'when'].some(textStarts) &&
-        ['do', 'can', 'to', 'give', 'cast', 'should'].some(textIncludes) &&
-        ['voting', 'vote', 'elect'].some(textIncludes);
+    return /^(?:where|how|want|when)\b/.test(text) &&
+        /\b(?:do|can|to|give|cast|should)\b/.test(text) &&
+        /\b(?:voting|vote|elect)\b/.test(text);
 };
 
 /**
@@ -46,13 +37,12 @@ const isAskedAboutVoting = (text) => {
  * @returns {boolean}
  */
 const isAskedForCandidateScore = (text) => {
-    const textIncludes = text.includes.bind(text);
-
-    return text.includes('candidate score') ||
-        (['can i '].some(textIncludes) &&
-            ['be', 'become', 'nominate', 'run'].some(textIncludes) &&
-            ['mod', 'election'].some(textIncludes));
+    return /candidate score/.test(text) ||
+        /can i /.test(text) &&
+        /be|become|nominate|run/.test(text) &&
+        /mod|election/.test(text);
 };
+
 
 /**
  * @summary checks if the message asked to tell who the current mods are
@@ -60,8 +50,7 @@ const isAskedForCandidateScore = (text) => {
  * @returns {boolean}
  */
 const isAskedForCurrentMods = (text) => {
-    const textIncludes = text.includes.bind(text);
-    return ['who', 'current', 'mod'].every(textIncludes);
+    return ['who', 'current', 'mod'].every((t) => text.includes(t));
 };
 
 /**
@@ -70,10 +59,7 @@ const isAskedForCurrentMods = (text) => {
  * @returns {boolean}
  */
 const isAskedForCurrentWinners = (text) => {
-    const textIncludes = text.includes.bind(text);
-    const textStarts = text.startsWith.bind(text);
-
-    return ['who'].some(textStarts) && ['winners', 'new mod', 'will win', 'future mod'].some(textIncludes);
+    return /^who/.test(text) && /winners|new mod|will win|future mod/.test(text);
 };
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -411,7 +411,7 @@ const main = async () => {
                 return `*setting up test cron job*`;
             });
 
-            commander.add("get cron", "lists schedulued announcements", ({ schedules }) => {
+            commander.add("get cron", "lists scheduled announcements", ({ schedules }) => {
                 return 'Currently scheduled announcements: `' + JSON.stringify(schedules) + '`';
             });
 

--- a/src/index.js
+++ b/src/index.js
@@ -524,6 +524,13 @@ const main = async () => {
                     `Why am I here? To serve the community`,
                 ).getRandom();
             }
+            else if (/thanks?(?: you)?/.test(content)) {
+                responseText = new RandomArray(
+                    "You are welcome",
+                    "My pleasure",
+                    "Not at all"
+                ).getRandom();
+            }
             else if (['help', 'command', 'info'].some(x => content.includes(x))) {
                 responseText = '\n' + ['Examples of election FAQs I can help with:',
                     'how does the election work', 'who are the candidates', 'how to nominate',

--- a/src/index.js
+++ b/src/index.js
@@ -231,9 +231,7 @@ async function announceWinners(election = null) {
 
     const { length } = arrWinners;
 
-    if (debug) {
-        console.log('announceWinners() called: ', arrWinners);
-    }
+    if (debug) console.log('announceWinners() called: ', arrWinners);
 
     // Needs to have ended and have winners
     if (phase != 'ended' || length === 0) return false;

--- a/src/messages.js
+++ b/src/messages.js
@@ -65,6 +65,7 @@ const sayAreModsPaid = (election) => {
 };
 
 /**
+ * TODO: do not add nomination phase if not started
  * @summary Default election message
  * @param {Election} election
  * @returns {string}
@@ -164,7 +165,7 @@ const sayMissingBadges = (badgeNames, count, required = false) => ` The user is 
  * @summary builds current mods list response message
  * @param {Election} election
  * @param {import("./utils.js").ResItem[]} currMods
- * @param {import("html-entities").decode} decodeEntities
+ * @param {import("html-entities").AllHtmlEntities["decode"]} decodeEntities
  * @returns {string}
  */
 const sayCurrentMods = (election, currMods, decodeEntities) => {
@@ -249,7 +250,7 @@ const sayElectionSchedule = (election) => {
     const maxPhaseLen = Math.max(...dateMap.map(([{ length }]) => length));
 
     const phases = dateMap.map(
-        ([ph, date]) => `    ${capitalize(ph)}: ${" ".repeat(maxPhaseLen - ph.length)}${date}${ph === phase ? arrow : ""}`
+        ([ph, date]) => `    ${capitalize(ph)}: ${" ".repeat(maxPhaseLen - ph.length)}${date || "never"}${ph === phase ? arrow : ""}`
     );
 
     return [prefix, ...phases].join("\n");

--- a/src/messages.js
+++ b/src/messages.js
@@ -221,7 +221,7 @@ const sayCurrentWinners = (election) => {
     const { length } = arrWinners;
 
     if (phase === 'ended' && length > 0) {
-        const winnerNames = arrWinners.map(({ userName, userId }) => makeURL(userName, `/${siteUrl}/users/${userId}`));
+        const winnerNames = arrWinners.map(({ userName, userId }) => makeURL(userName, `${siteUrl}/users/${userId}`));
         return `The winner${pluralize(length)} ${length > 1 ? 'are' : 'is'}: ${winnerNames.join(', ')}.`;
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,6 +37,7 @@ const startServer = () => {
 
 /**
  * @typedef {{
+ *  id: string,
  *  site_url: string,
  *  user_id: string,
  *  user: {
@@ -49,7 +50,16 @@ const startServer = () => {
  * }} ResItem
  *
  * @typedef {{
+ *   user: { reputation: number },
+ *   badge_id: number,
+ *   link: string,
+ *   name: string,
+ *   rank: "bronze" | "silver" | "gold"
+ * }} BadgeItem
+ *
+ * @typedef {{
  *  items: ResItem[] //TODO: split into API entities
+ *  has_more: boolean
  * }} APIListResponse
  */
 
@@ -58,7 +68,7 @@ const startServer = () => {
  * @summary fetches the endpoint
  * @param {string} url
  * @param {boolean} [json]
- * @returns {Promise<APIListResponse|string|null>}
+ * @returns {Promise<any>}
  */
 const fetchUrl = async (url, json = false) => {
     const { SOURCE_VERSION, ACCOUNT_EMAIL, DEBUG } = process.env;
@@ -261,8 +271,15 @@ const getSiteUserIdFromChatStackExchangeId = async (chatUserId, chatdomain, site
 const makeURL = (label, uri) => `[${label}](${uri})`;
 
 /**
- * @typedef {{ name: string, required?: boolean }} Badge
+ * @typedef {{ id:string, name: string, required?: boolean }} Badge
  */
+
+/**
+ * @summary callback for mapping badge to name
+ * @param {BadgeItem} badge
+ * @returns {string}
+ */
+const mapToId = ({ badge_id }) => badge_id.toString();
 
 /**
  * @summary callback for mapping badge to name
@@ -279,6 +296,7 @@ const mapToName = ({ name }) => name;
 const mapToRequired = ({ required }) => required;
 
 module.exports = {
+    mapToId,
     mapToName,
     mapToRequired,
     startServer,

--- a/test/commands.js
+++ b/test/commands.js
@@ -16,7 +16,7 @@ describe('Commander', () => {
 
         it('should correctly list aliases', () => {
             const help = commander.help();
-            expect(help).to.equal(`- [bark] (say) barks, what else?`);
+            expect(help).to.equal(`Commands\n- [bark] (say) barks, what else?`);
         });
 
     });

--- a/test/commands.js
+++ b/test/commands.js
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import { CommandManager } from "../src/commands";
+
+describe('Commander', () => {
+
+    describe('aliases', () => {
+
+        const commander = new CommandManager();
+        commander.add("bark", "barks, what else?", () => "bark!");
+        commander.alias("bark", ["say"]);
+
+        it('should correctly add aliases', () => {
+            expect(commander.commands.bark.aliases).length(1);
+            expect(commander.commands.say.aliasFor).to.not.be.null;
+        });
+
+        it('should correctly list aliases', () => {
+            const help = commander.help();
+            expect(help).to.equal(`- [bark] (say) barks, what else?`);
+        });
+
+    });
+
+});

--- a/test/election.js
+++ b/test/election.js
@@ -12,11 +12,25 @@ describe('Election', () => {
             const tomorrow = dateToUtcTimestamp(new Date(now + 864e5));
             const yesterday = dateToUtcTimestamp(new Date(now - 864e5));
 
-            const noPhase = Election.getPhase(tomorrow, tomorrow, tomorrow, tomorrow);
-            const nomination = Election.getPhase(yesterday, tomorrow, tomorrow, tomorrow);
-            const primary = Election.getPhase(tomorrow, tomorrow, yesterday, tomorrow);
-            const start = Election.getPhase(tomorrow, yesterday, tomorrow, tomorrow);
-            const ended = Election.getPhase(yesterday, yesterday, yesterday, yesterday);
+            const election = new Election("https://stackoverflow.com/election/12", 12);
+            election.dateElection = tomorrow;
+            election.dateEnded = tomorrow;
+            election.datePrimary = tomorrow;
+            election.dateNomination = tomorrow;
+
+            const noPhase = Election.getPhase(election);
+
+            election.dateNomination = yesterday;
+            const nomination = Election.getPhase(election);
+
+            election.datePrimary = yesterday;
+            const primary = Election.getPhase(election);
+
+            election.dateElection = yesterday;
+            const start = Election.getPhase(election);
+
+            election.dateEnded = yesterday;
+            const ended = Election.getPhase(election);
 
             expect(noPhase).to.equal(null);
             expect(nomination).to.equal("nomination");

--- a/test/election.js
+++ b/test/election.js
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import Election from "../src/Election";
+import { dateToUtcTimestamp } from "../src/utils";
+
+describe('Election', () => {
+
+    describe('getPhase', () => {
+
+        it('should correctly determine phase', () => {
+            const now = Date.now();
+
+            const tomorrow = dateToUtcTimestamp(new Date(now + 864e5));
+            const yesterday = dateToUtcTimestamp(new Date(now - 864e5));
+
+            const noPhase = Election.getPhase(tomorrow, tomorrow, tomorrow, tomorrow);
+            const nomination = Election.getPhase(yesterday, tomorrow, tomorrow, tomorrow);
+            const primary = Election.getPhase(tomorrow, tomorrow, yesterday, tomorrow);
+            const start = Election.getPhase(tomorrow, yesterday, tomorrow, tomorrow);
+            const ended = Election.getPhase(yesterday, yesterday, yesterday, yesterday);
+
+            expect(noPhase).to.equal(null);
+            expect(nomination).to.equal("nomination");
+            expect(primary).to.equal("primary");
+            expect(start).to.equal("election");
+            expect(ended).to.equal("ended");
+        });
+
+    });
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "declaration": false,
     "target": "ES6",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Phew, took a little while a finish - this PR introduces an assortment of updates to either fix or improved ElectionBot performance in the field, including:

- fix over the today's hotfix for the `html-entities` package import
- patch for ChatExchange until the pending PR is finalized
- slightly reworked message guards to allow for higher precision of regular expressions
- basic paging for API request for user badges
- some minor fixes based on live tests (like me forgetting to negate `isEligible`)
- split `BadgeItem` and `ResItem` typedefs
- and a command to brew some coffee, I hope you do not mind 😇