### PR TITLE
And some more changes!

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: dependencies
       - name: Using Node 14
         uses: actions/setup-node@v1
         with:

--- a/src/api.js
+++ b/src/api.js
@@ -4,13 +4,14 @@ import { apiBase, apiVer, fetchUrl } from "./utils.js";
  * @typedef {import("./utils.js").BadgeItem} BadgeItem
  *
  * @summary gets badges from the API
+ * @param {import("./index.js").BotConfig} config
  * @param {import("chatexchange/dist/Browser").IProfileData} user user to request badges for
  * @param {string} site election site slug
  * @param {string} key api key
  * @param {number} [page]
  * @returns {Promise<BadgeItem[]>}
  */
-export const getBadges = async (user, site, key, page = 1) => {
+export const getBadges = async (config, user, site, key, page = 1) => {
     const { id } = user;
 
     const badgeURI = new URL(`${apiBase}/${apiVer}/users/${id}/badges`);
@@ -23,10 +24,10 @@ export const getBadges = async (user, site, key, page = 1) => {
         key
     }).toString();
 
-    const { items = [], has_more } = /**@type {{ items: BadgeItem[], has_more: boolean }} */(await fetchUrl(badgeURI.toString(), true)) || {};
+    const { items = [], has_more } = /**@type {{ items: BadgeItem[], has_more: boolean }} */(await fetchUrl(config, badgeURI.toString(), true)) || {};
 
     if (has_more) {
-        const otherItems = await getBadges(user, site, key, page + 1);
+        const otherItems = await getBadges(config, user, site, key, page + 1);
         return [...items, ...otherItems];
     }
 

--- a/src/election.js
+++ b/src/election.js
@@ -172,11 +172,12 @@ export default class Election {
 
                 const [statusElem, resultsElem, statsElem] = resultsWrapper.find(".flex--item").get();
 
-                const resultsURL = $(resultsElem).find('a').first().attr('href');
+                const resultsURL = $(resultsElem).find('a').first().attr('href') || "";
 
-                // Get results URL
                 this.resultsUrl = resultsURL;
-                if (!resultsURL.includes('opavote.com')) this.resultsUrl = ''; // incorrect/not available immediately
+
+                // incorrect/not available immediately
+                if (!resultsURL.includes('opavote.com')) this.resultsUrl = '';
 
                 // Check if election was cancelled?
                 if ($(statusElem).text().includes('cancelled')) {

--- a/src/election.js
+++ b/src/election.js
@@ -104,7 +104,10 @@ export default class Election {
         };
     }
 
-    async scrapeElection() {
+    /**
+     * @param {import("./index.js").BotConfig} config
+     */
+    async scrapeElection(config) {
 
         // Save prev values so we can compare changes after
         this._prevObj = Object.assign({}, this); // fast way of cloning an object
@@ -113,7 +116,7 @@ export default class Election {
         const electionPageUrl = `${this.electionUrl}?tab=nomination`;
 
         try {
-            const pageHtml = await fetchUrl(electionPageUrl);
+            const pageHtml = await fetchUrl(config, electionPageUrl);
 
             // Parse election page
             const $ = cheerio.load(/** @type {string} */(pageHtml));

--- a/src/guards.js
+++ b/src/guards.js
@@ -61,3 +61,12 @@ export const isAskedForCurrentMods = (text) => {
 export const isAskedForCurrentWinners = (text) => {
     return /^who/.test(text) && /winners|new mod|will win|future mod/.test(text);
 };
+
+/**
+ * @summary checks if the message asked to tell who nominees are
+ * @param {string} text
+ * @returns {boolean}
+ */
+export const isAskedForCurrentNominees = (text) => {
+    return /(?:who|what) (?:are|were|was|is)/.test(text) && /(?:nomin(?:ee|ation)|participant|candidate)s?/.test(text);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -470,11 +470,11 @@ const announcement = new Announcement();
                 });
 
                 commander.add("timetravel", "sends bot back in time to another phase", (election, content) => {
-                    const [, yyyy, MM, dd] = /(\d{4})-(\d{2})-(\d{2})/.exec(content) || [];
+                    const [, yyyy, MM, dd, today] = /(?:(\d{4})-(\d{2})-(\d{2}))|(today)/.exec(content) || [];
 
-                    if (!yyyy || !MM || !dd) return "Sorry, Doc! Invalid coordinates";
+                    if (!today && (!yyyy || !MM || !dd)) return "Sorry, Doc! Invalid coordinates";
 
-                    const destination = new Date(+yyyy, +MM - 1, +dd);
+                    const destination = today ? new Date() : new Date(+yyyy, +MM - 1, +dd);
 
                     const phase = Election.getPhase(election, destination);
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Election from './election.js';
 import {
     isAskedAboutVoting,
     isAskedForCandidateScore, isAskedForCurrentMods,
+    isAskedForCurrentNominees,
     isAskedForCurrentWinners, isAskedIfModsArePaid,
     isAskedWhyNominationRemoved
 } from "./guards.js";
@@ -678,8 +679,7 @@ const announcement = new Announcement();
                 let responseText = null;
 
                 // Current candidates
-                if (['who are', 'who is', 'who has', 'how many'].some(x => content.startsWith(x)) && ['nominees', 'nominated', 'nominations', 'candidate'].some(x => content.includes(x))) {
-
+                if (isAskedForCurrentNominees(content)) {
                     if (election.phase === null) {
                         responseText = sayNotStartedYet(election);
                     }

--- a/src/index.js
+++ b/src/index.js
@@ -916,21 +916,21 @@ const announcement = new Announcement();
         // Interval to re-scrape election data
         rescraperInt = setInterval(async function () {
 
-            await election.scrapeElection();
+            await election.scrapeElection(BotConfig);
             announcement.setElection(election);
 
-            if (BotConfig.debug) {
-                // Log scraped election info
+            if (BotConfig.verbose) {
                 console.log('SCRAPE', election.updated, election);
+            }
 
-                // Log election winners
-                if (election.phase === 'ended') {
-                    console.log('Election winners', election.arrWinners);
+            if (BotConfig.debug) {
+                const { arrNominees, arrWinners, phase } = election;
+
+                if (phase === 'ended') {
+                    console.log(`Election winners: ${arrWinners}`);
                 }
-                // Log election candidates
-                else {
-                    console.log('Election candidates', election.arrNominees);
-                }
+
+                console.log(`Election candidates: ${arrNominees}`);
             }
 
             // No previous scrape results yet, do not proceed

--- a/src/index.js
+++ b/src/index.js
@@ -375,9 +375,11 @@ const announcement = new Announcement();
 
             const isPrivileged = user.isModerator || adminIds.includes(resolvedMsg.userId);
 
-            // If message is too short or long, ignore (most likely FP)
-            if (content.length < 4 || content.length > 69) {
-                console.log(`EVENT - Ignoring due to message length ${resolvedMsg.content.length}: `, resolvedMsg.content);
+            // If message is too short or long, ignore (most likely FP, except if an admin issues the message)
+            const { length } = content;
+            if ((length < 4 || length > 69) && !isPrivileged) {
+                const { content } = resolvedMsg;
+                console.log(`EVENT - Ignoring due to message length ${content.length}: ${content}`);
                 return;
             }
 

--- a/src/index.js
+++ b/src/index.js
@@ -502,6 +502,13 @@ const announcement = new Announcement();
                 commander.add("help", "Prints usage info", () => commander.help("moderator commands (requires mention):"));
                 commander.alias("help", ["usage", "commands"]);
 
+                commander.add("die", "shuts down the bot in case of emergency", () => {
+                    setTimeout(() => process.exit(0), 3e3);
+                    return "initiating shutdown sequence";
+                });
+
+                commander.alias("die", ["shutdown"]);
+
                 const outputs = [
                     ["help", /help|usage|commands/],
                     ["say", /say/, origContent],
@@ -516,7 +523,8 @@ const announcement = new Announcement();
                     ["timetravel", /88 miles|delorean|timetravel/, election, content],
                     ["unmute", /unmute|clear timeout/, BotConfig],
                     ["mute", /mute|timeout|sleep/, BotConfig, content, BotConfig.throttleSecs],
-                    ["debug", /debug(?:ing)?/, BotConfig, content]
+                    ["debug", /debug(?:ing)?/, BotConfig, content],
+                    ["die", /die|shutdown|turn off/]
                 ];
 
                 responseText = outputs.reduce(

--- a/src/score.js
+++ b/src/score.js
@@ -42,6 +42,7 @@ export const makeIsEligible = (requiredRep) =>
 
 /**
  * @summary HOF with common parameters
+ * @param {import("./index.js").BotConfig} config
  * @param {string} hostname
  * @param {string} chatDomain
  * @param {string} apiSlug
@@ -49,7 +50,7 @@ export const makeIsEligible = (requiredRep) =>
  * @param {import("./utils").Badge[]} badges
  * @param {number[]} modIds
  */
-export const makeCandidateScoreCalc = (hostname, chatDomain, apiSlug, apiKey, badges, modIds) =>
+export const makeCandidateScoreCalc = (config, hostname, chatDomain, apiSlug, apiKey, badges, modIds) =>
     /**
      * @summary calculates candidate score
      * @param {Election} election
@@ -91,7 +92,7 @@ export const makeCandidateScoreCalc = (hostname, chatDomain, apiSlug, apiKey, ba
         }
         // If not Chat.SO, resolve election site user id from chat id (chat has different ids)
         else if (!chatDomain.includes('stackoverflow.com')) {
-            userId = await getSiteUserIdFromChatStackExchangeId(userId, chatDomain, hostname);
+            userId = await getSiteUserIdFromChatStackExchangeId(config, userId, chatDomain, hostname);
 
             // Unable to get user id on election site
             if (userId === null) {
@@ -100,7 +101,7 @@ export const makeCandidateScoreCalc = (hostname, chatDomain, apiSlug, apiKey, ba
             }
         }
 
-        const items = await getBadges(user, apiSlug, apiKey);
+        const items = await getBadges(config, user, apiSlug, apiKey);
 
         // Validation
         if (!items.length) {


### PR DESCRIPTION
This PR is utility-centric - for an overview, the changes are:

1. Minor bugfixes in election page scraping
2. New message guard (when asking for current nominees)
3. Verbose logging level (to avoid cluttering the output with the election page content during normal debugging)
4. Bugfix for automated dependency update workflow (it tried to checkout and push to `master` yesterday)
5. Ignoring message length limit for privileged users (to make the `die` command work)
6. New `die` (or `shutdown`) command (privileged) for making the bot gracefully shutdown on demand
7. `today` shorthand for the `delorean` privileged command (convenient when jumping between election phases)