### PR TITLE
Bugfix and improvement for the sayHI message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -509,6 +509,9 @@ const announcement = new Announcement();
 
                 commander.alias("die", ["shutdown"]);
 
+                commander.add("greet", "makes the bot welcome everyone", sayHI);
+                commander.alias("greet", ["welcome"]);
+
                 const outputs = [
                     ["help", /help|usage|commands/],
                     ["say", /say/, origContent],
@@ -524,7 +527,8 @@ const announcement = new Announcement();
                     ["unmute", /unmute|clear timeout/, BotConfig],
                     ["mute", /mute|timeout|sleep/, BotConfig, content, BotConfig.throttleSecs],
                     ["debug", /debug(?:ing)?/, BotConfig, content],
-                    ["die", /die|shutdown|turn off/]
+                    ["die", /die|shutdown|turn off/],
+                    ["greet", /^(greet|welcome)/, room, election]
                 ];
 
                 responseText = outputs.reduce(

--- a/src/messages.js
+++ b/src/messages.js
@@ -10,13 +10,11 @@ import {
 
 /**
  * @summary makes bot remind users that they are here
- * @param {{ sendMessage(text:string): Promise<void> }} room //TODO: redefine
+ * @param {{ sendMessage(text:string): Promise<void> }} room
  * @param {Election} election
  * @returns {Promise<void>}
  */
 export const sayHI = async (room, election) => {
-    let responseText = 'Welcome to the election chat room! ';
-
     const { arrNominees, electionUrl, phase } = election;
 
     const { length } = arrNominees;
@@ -24,22 +22,21 @@ export const sayHI = async (room, election) => {
     const electionLink = makeURL("election", `${electionUrl}?tab=${phase}`);
     const phasePrefix = `The ${electionLink} is in the ${phase} phase`;
 
-    //TODO: change 'null' to empty string (no type hopping)
     const phaseMap = {
         "null": `The ${electionLink} has not begun yet.`,
         "ended": `The ${electionLink} has ended.`,
         "cancelled": `The ${electionLink} has been cancelled.`,
-        "nomination": `The ${electionLink} is in the ${phase} phase, and currently there are ${length} candidates.`,
-        "primary": `The ${electionLink} is in the ${phase} phase, and currently there are ${length} candidates.`,
+        "nomination": `${phasePrefix}, and currently there are ${length} candidates.`,
+        "primary": `${phasePrefix}, and currently there are ${length} candidates.`,
     };
 
-    responseText += phaseMap[JSON.stringify(phase)];
-
+    const greeting = 'Welcome to the election chat room! ';
+    const phaseText = phaseMap[phase] || "";
     const helpCommand = `@ElectionBot help`;
 
-    responseText += ` I can answer frequently-asked questions about the election - type *${helpCommand}* for more info.`;
+    const text = `${greeting}${phaseText} I can answer frequently-asked questions about elections (type *${helpCommand}* for more info).`;
 
-    await room.sendMessage(responseText);
+    await room.sendMessage(text);
 };
 
 /**

--- a/test/messages.js
+++ b/test/messages.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import Election from "../src/election.js";
-import { sayBadgesByType, sayElectionSchedule, sayInformedDecision } from "../src/messages.js";
+import { sayBadgesByType, sayElectionSchedule, sayHI, sayInformedDecision } from "../src/messages.js";
 import { capitalize } from "../src/utils.js";
 
 describe("Messages module", () => {
@@ -79,6 +79,39 @@ describe("Messages module", () => {
         it("should return empty message if 'qnaUrl' is present", () => {
             const nonEmpty = sayInformedDecision(/** @type {Election} */({ qnaUrl: "stackoverflow.com" }));
             expect(nonEmpty).to.be.not.empty;
+        });
+
+    });
+
+    describe('sayHI', () => {
+
+        it('should not add phase info on no phase', async () => {
+            const election = new Election("https://ja.stackoverflow.com/election");
+
+            const mockRoom = {
+                async sendMessage(txt) {
+                    expect(txt).to.not.match(/is in the.*? phase/);
+                }
+            };
+
+            await sayHI(mockRoom, election);
+        });
+
+        it('should correctly add phase info', async () => {
+            const electionLink = "https://stackoverflow.com/election/12";
+
+            const phase = "cancelled";
+
+            const election = new Election(electionLink, 12);
+            election.phase = phase;
+
+            const mockRoom = {
+                async sendMessage(txt) {
+                    expect(txt).to.match(new RegExp(`The \\[election\\]\\(${electionLink}\\?tab=${phase}\\) has been cancelled.`));
+                }
+            };
+
+            await sayHI(mockRoom, election);
         });
 
     });


### PR DESCRIPTION
This is a small PR making some smaller changes that fix and optimize the `sayHI` message builder:

- added defaults for no phase info on sayHI call (to avoid the "election is in the undefined phase" :))
- added tests for the `sayHI` builder
- added 'greet' (aliased as `welcome`) command for triggering the welcome message