### PR TITLE
Command access levels

### DIFF
--- a/src/guards.js
+++ b/src/guards.js
@@ -70,3 +70,21 @@ export const isAskedForCurrentWinners = (text) => {
 export const isAskedForCurrentNominees = (text) => {
     return /(?:who|what) (?:are|were|was|is)/.test(text) && /(?:nomin(?:ee|ation)|participant|candidate)s?/.test(text);
 };
+
+/**
+ * @summary checks if the message asked for current election schedule
+ * @param {string} text
+ * @returns {boolean}
+ */
+export const isAskedForElectionSchedule = (text) => {
+    return /(?:when|how) is the election(?: scheduled)?|election schedule/.test(text);
+};
+
+/**
+ * @summary checks if the message asked if anyone can edit in a ♦ in their username
+ * @param {string} text
+ * @returns {boolean}
+ */
+export const isAskedAboutUsernameDiamond = (text) => {
+    return /(?:edit|insert|add).+?(?:\u2666|diamond).+?(?:user)?name/.test(text);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -374,10 +374,10 @@ const announcement = new Announcement();
             if (ignoredEventTypes.includes(resolvedMsg.eventType)) return;
 
             // Ignore stuff from self, Community or Feeds users
-            if (meWithId.id == resolvedMsg.userId || resolvedMsg.userId <= 0) return;
+            if (meWithId.id === resolvedMsg.userId || resolvedMsg.userId <= 0) return;
 
             // Ignore stuff from ignored users
-            if (ignoredUserIds.includes(resolvedMsg.userId)) return;
+            if (BotConfig.ignoredUserIds.includes(resolvedMsg.userId)) return;
 
             // Ignore messages with oneboxes & links!
             if (content.includes('onebox') || content.includes('http')) return;

--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,18 @@ import entities from 'html-entities';
 import { AccessLevel, CommandManager } from './commands.js';
 import Election from './election.js';
 import {
+    isAskedAboutUsernameDiamond,
     isAskedAboutVoting,
     isAskedForCandidateScore, isAskedForCurrentMods,
     isAskedForCurrentNominees,
-    isAskedForCurrentWinners, isAskedIfModsArePaid,
+    isAskedForCurrentWinners, isAskedForElectionSchedule, isAskedIfModsArePaid,
     isAskedWhyNominationRemoved
 } from "./guards.js";
 import {
     sayAboutVoting,
     sayAreModsPaid, sayBadgesByType, sayCandidateScoreFormula, sayCurrentMods,
     sayCurrentWinners, sayElectionIsOver, sayElectionSchedule, sayHI, sayInformedDecision, sayNextPhase, sayNotStartedYet, sayOffTopicMessage, sayRequiredBadges,
+    sayWhatIsAnElection,
     sayWhatModsDo, sayWhyNominationRemoved
 } from "./messages.js";
 import { getRandomPlop, RandomArray } from "./random.js";
@@ -888,26 +890,18 @@ const announcement = new Announcement();
 
                 // What is an election
                 else if (content.length <= 56 && (/^what( i|')?s (an|the) election/.test(content) || /^how does (an|the) election work/.test(content))) {
-                    responseText = `An [election](https://meta.stackexchange.com/q/135360) is where users nominate themselves as candidates for the role of [diamond ♦ moderator](https://meta.stackexchange.com/q/75189), and users with at least ${election.repVote} reputation can vote for them.`;
+                    responseText = sayWhatIsAnElection(election);
                 }
-
-                // How/where to vote
                 else if (isAskedAboutVoting(content)) {
                     responseText = sayAboutVoting(election);
                 }
-
-                // Who are the winners
                 else if (isAskedForCurrentWinners(content)) {
                     responseText = sayCurrentWinners(election);
                 }
-
-                // Election schedule
-                else if (content.includes('election schedule') || content.includes('when is the election')) {
+                else if (isAskedForElectionSchedule(content)) {
                     responseText = sayElectionSchedule(election);
                 }
-
-                // Edit diamond into username
-                else if (['edit', 'insert', 'add'].some(x => content.includes(x)) && ['♦', 'diamond'].some(x => content.includes(x)) && content.includes('name')) {
+                else if (isAskedAboutUsernameDiamond(content)) {
                     responseText = `No one is able to edit the diamond symbol (♦) into their username.`;
                 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import {
     apiVer, dateToRelativetime,
     dateToUtcTimestamp, fetchUrl, keepAlive,
     linkToRelativeTimestamp,
-    linkToUtcTimestamp, makeURL, mapToName, mapToRequired, pluralize, startServer
+    linkToUtcTimestamp, makeURL, mapToName, mapToRequired, parseIds, pluralize, startServer
 } from './utils.js';
 
 // preserves compatibility with older import style
@@ -66,8 +66,6 @@ const announcement = new Announcement();
     const electionSiteHostname = electionUrl.split('/')[2];
     const electionSiteUrl = 'https://' + electionSiteHostname;
     const electionSiteApiSlug = electionSiteHostname.replace('.stackexchange.com', '');
-    const adminIds = (process.env.ADMIN_IDS || '').split(/\D+/).map(Number);
-    const ignoredUserIds = (process.env.IGNORED_USERIDS || '').split(/\D+/).map(Number);
     const scrapeIntervalMins = +(process.env.SCRAPE_INTERVAL_MINS) || 5;
     const stackApikey = process.env.STACK_API_KEY;
 
@@ -157,7 +155,11 @@ const announcement = new Announcement();
         // Debug mode
         debug: JSON.parse(process.env.DEBUG?.toLowerCase() || "false"),
         // Verbose logging
-        verbose: JSON.parse(process.env.VERBOSE?.toLowerCase() || "false")
+        verbose: JSON.parse(process.env.VERBOSE?.toLowerCase() || "false"),
+        //user ids by level
+        adminIds: parseIds(process.env.ADMIN_IDS || ''),
+        ignoredUserIds: parseIds(process.env.IGNORED_USERIDS || ''),
+        devIds: parseIds(process.env.DEV_IDS || ""),
     };
 
     // Overrides console.log/error to insert newlines
@@ -178,8 +180,9 @@ const announcement = new Announcement();
         console.log('electionUrl:', electionUrl);
         console.log('electionSiteHostname:', electionSiteHostname);
         console.log('electionSiteUrl:', electionSiteUrl);
-        console.log('adminIds:', adminIds.join(', '));
-        console.log('ignoredUserIds:', ignoredUserIds.join(', '));
+
+        Object.entries(BotConfig).forEach(([key, val]) => console.log(key, val));
+
         console.log('scrapeIntervalMins:', scrapeIntervalMins);
         console.log('lowActivityCheckMins:', lowActivityCheckMins);
         console.log('lowActivityCountThreshold:', lowActivityCountThreshold);

--- a/src/messages.js
+++ b/src/messages.js
@@ -323,3 +323,18 @@ export const sayCandidateScoreFormula = (badges) => {
 
     return `The ${allPts}-point ${makeURL("candidate score", "https://meta.stackexchange.com/a/252643")} is calculated this way: ${formula}`;
 };
+
+/**
+ * @summary builds an election definition message
+ * @param {Election} election
+ * @returns {string}
+ */
+export const sayWhatIsAnElection = (election) => {
+    const { repVote } = election;
+
+    const diamondURL = makeURL("diamond ♦ moderator", "https://meta.stackexchange.com/q/75189");
+    const electionURL = makeURL("election", "https://meta.stackexchange.com/q/135360");
+    const eligibility = `users with at least ${repVote} reputation can vote for them`;
+
+    return `An ${electionURL} is where users nominate themselves as candidates for the role of ${diamondURL}, and ${eligibility}.`;
+};

--- a/src/score.js
+++ b/src/score.js
@@ -5,13 +5,10 @@ import { getRandomOops } from "./random.js";
 import { getSiteUserIdFromChatStackExchangeId, makeURL, mapToId, mapToName, mapToRequired, pluralize } from "./utils.js";
 
 /**
- * @typedef {{
- *  eventType: string,
- *  userName: string,
- *  userId: number,
- *  targetUserId?: number,
- *  content: string,
- * }} resolvedMsg
+ * @typedef {import("chatexchange/dist/Browser").IProfileData} User
+ * @typedef {import("./index.js").BotConfig} BotConfig
+ * @typedef {import("./utils").Badge} Badge
+ * @typedef {import("./index.js").ResolvedMessage} ResolvedMessage
  */
 
 /**
@@ -42,20 +39,20 @@ export const makeIsEligible = (requiredRep) =>
 
 /**
  * @summary HOF with common parameters
- * @param {import("./index.js").BotConfig} config
+ * @param {BotConfig} config
  * @param {string} hostname
  * @param {string} chatDomain
  * @param {string} apiSlug
  * @param {string} apiKey
- * @param {import("./utils").Badge[]} badges
+ * @param {Badge[]} badges
  * @param {number[]} modIds
  */
 export const makeCandidateScoreCalc = (config, hostname, chatDomain, apiSlug, apiKey, badges, modIds) =>
     /**
      * @summary calculates candidate score
      * @param {Election} election
-     * @param {import("chatexchange/dist/Browser").IProfileData} user
-     * @param {resolvedMsg} message
+     * @param {User} user
+     * @param {ResolvedMessage} message
      * @param {boolean} [isSO]
      * @returns {Promise<string>}
      */

--- a/src/utils.js
+++ b/src/utils.js
@@ -331,3 +331,10 @@ export const mapToName = ({ name }) => name;
  * @returns {boolean}
  */
 export const mapToRequired = ({ required }) => required;
+
+/**
+ * @summary parses user ids from ENV
+ * @param {string} ids
+ * @returns {number[]}
+ */
+export const parseIds = (ids) => ids.split(/\D+/).map(Number);

--- a/test/commands.js
+++ b/test/commands.js
@@ -1,11 +1,26 @@
 import { expect } from "chai";
-import { CommandManager } from "../src/commands.js";
+import { AccessLevel, CommandManager } from "../src/commands.js";
 
 describe('Commander', () => {
 
-    describe('aliases', () => {
+    const getMockUser = (overrides = {}) => {
+        const defaults = {
+            access: AccessLevel.dev,
+            id: 42,
+            name: "Answer",
+            isModerator: false,
+            about: "",
+            roomCount: 1,
+            messageCount: 0,
+            reputation: 42,
+            lastSeen: Date.now(),
+            lastMessage: Date.now()
+        };
+        return Object.assign(defaults, overrides);
+    };
 
-        const commander = new CommandManager();
+    describe('aliases', () => {
+        const commander = new CommandManager(getMockUser());
         commander.add("bark", "barks, what else?", () => "bark!");
         commander.alias("bark", ["say"]);
 
@@ -17,6 +32,34 @@ describe('Commander', () => {
         it('should correctly list aliases', () => {
             const help = commander.help();
             expect(help).to.equal(`Commands\n- [bark] (say) barks, what else?`);
+        });
+
+    });
+
+    describe('AccessLevel', () => {
+        const commander = new CommandManager(getMockUser());
+        commander.add("destroy", "Destroys the universe", () => "💥", AccessLevel.dev);
+        commander.add("restart", "Restarts the bot", () => true, AccessLevel.privileged);
+        commander.add("pet", "Pets the bot", () => "good bot! Who's a good bot?", AccessLevel.all);
+
+        it('should allow privileged commands for privileged users', () => {
+            const boom = commander.run("destroy");
+            expect(boom).to.not.be.undefined;
+
+            const pet = commander.run("pet");
+            expect(pet).to.not.be.undefined;
+
+            const restart = commander.run("restart");
+            expect(restart).to.not.be.undefined;
+        });
+
+        it('should disallow privileged commands for underprivileged users', () => {
+            commander.user = getMockUser({ access: AccessLevel.user });
+            const poof = commander.run("destroy");
+            expect(poof).to.be.undefined;
+
+            const restart = commander.run("restart");
+            expect(restart).to.be.undefined;
         });
 
     });

--- a/test/guards.js
+++ b/test/guards.js
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import { isAskedAboutUsernameDiamond, isAskedForElectionSchedule } from "../src/guards.js";
+
+describe('Message Guards', () => {
+
+    describe('isAskedForElectionSchedule', () => {
+
+        it('should correctly match content', () => {
+
+            const matches = [
+                "when is the election?",
+                "what is the election schedule?",
+                "how is the election scheduled?",
+                "election schedule, please"
+            ];
+
+            matches.forEach((txt) => {
+                const matched = isAskedForElectionSchedule(txt);
+                expect(matched, `<${txt}> not matched`).to.be.true;
+            });
+        });
+
+    });
+
+    describe('isAskedAboutUsernameDiamond', () => {
+
+        it('should correctly match content', () => {
+
+            const matches = [
+                "edit diamond into name",
+                "can somebody edit a ♦ into their username?",
+                "can someone add a diamond to their name?"
+            ];
+
+            matches.forEach((txt) => {
+                const matched = isAskedAboutUsernameDiamond(txt);
+                expect(matched, `<${txt}> not matched`).to.be.true;
+            });
+
+        });
+
+    });
+
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { listify, pluralize } from "../src/utils.js";
+import { listify, parseIds, pluralize } from "../src/utils.js";
 
 describe('String-related utils', () => {
 
@@ -27,6 +27,15 @@ describe('String-related utils', () => {
         it('should pluralize otherwise', () => {
             const plural = pluralize(10, "es");
             expect(plural).to.equal("es");
+        });
+
+    });
+
+    describe('parseIds', () => {
+
+        it('should parse id strings correctly', () => {
+            const parsed = parseIds("1234|56789|101010");
+            expect(parsed).to.deep.equal([1234, 56789, 101010]);
         });
 
     });


### PR DESCRIPTION
This PR enhances the `Command` and `CommandManager` classes to make them user access-level aware. Initial implementation introduces 5 access levels (bitwise masks):

| Level | Permissions | Mask |
| - | - | - |
| `user` | default level, no permissions | `1` |
| `admin` | manager level, no dev permissions | `2` |
| `dev` | admin level, full permissions | `4` |
| `privileged` | `admin` level or higher | `2 \| 4` |
| `all` | unprivileged access | `1\|2\|4` |

New functionality is covered by unit tests as well. Addresses #59 

List of developer ids is passed in as the `DEV_IDS` environment variable