### PR TITLE
Access level filtering of commands & some minor changes

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -112,6 +112,14 @@ export class CommandManager {
     }
 
     /**
+     * @summary aliases multiple commands
+     * @param {{ [command: string]: string[] }} dict
+     */
+    aliases(dict) {
+        Object.entries(dict).forEach(([name, aliases]) => this.alias(name, aliases));
+    }
+
+    /**
      * @summary runs a command by name
      * @param {string} name
      * @param {...any} args

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,0 +1,33 @@
+/**
+ * @summary changes user access level (can only de-elevate)
+ * @param {import("../index").BotConfig} config bot config
+ * @param {import("../index").User} user message author
+ * @param {string} content incoming message content
+ * @returns {string}
+ */
+export const setAccessCommand = (config, user, content) => {
+    const [, userId, level] = /set (?:access|level)\s+(\d+|me)\s+(user|admin|dev)/.exec(content) || [];
+    if (!level) return "Please provide access level";
+
+    const uid = userId === "me" ? user.id : +userId;
+
+    if (config.debug) console.log({ userId, level, uid });
+
+    //TODO: move to user-based from id-based checks
+    const { adminIds, devIds } = config;
+
+    const changeMap = {
+        "user": () => {
+            adminIds.delete(uid);
+            devIds.delete(uid);
+        },
+        "admin": () => {
+            devIds.delete(uid);
+            adminIds.add(uid);
+        }
+    };
+
+    changeMap[level]?.();
+
+    return `Changed access level of ${uid} to ${level}`;
+};

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("./index").User} User
+ * @typedef {import("../index").User} User
  */
 
 export const AccessLevel = {
@@ -165,7 +165,7 @@ export class CommandManager {
     help(prefix = "Commands") {
         const { commands } = this;
         const list = Object.values(commands)
-            .filter(({ aliasFor }) => !aliasFor)
+            .filter((cmd) => !cmd.aliasFor && this.canRun(cmd))
             .map(({ name, description, aliases }) => {
                 const aliasNames = aliases.map(({ name }) => name).join(", ");
                 const alias = aliasNames ? ` (${aliasNames})` : "";

--- a/src/index.js
+++ b/src/index.js
@@ -582,7 +582,7 @@ const announcement = new Announcement();
                 ];
 
                 responseText = outputs.reduce(
-                    (a, args) => a || commander.runIfMatches.call(commander, content, ...args)
+                    (a, args) => a || commander.runIfMatches.call(commander, content, ...args) || ""
                     , "");
 
                 if (BotConfig.debug) {

--- a/src/index.js
+++ b/src/index.js
@@ -544,11 +544,13 @@ const announcement = new Announcement();
 
                 commander.add("greet", "makes the bot welcome everyone", sayHI, AccessLevel.privileged);
 
-                commander.alias("timetravel", ["delorean", "88 miles"]);
-                commander.alias("mute", ["timeout", "sleep"]);
-                commander.alias("commands", ["usage"]);
-                commander.alias("die", ["shutdown"]);
-                commander.alias("greet", ["welcome"]);
+                commander.aliases({
+                    timetravel: ["delorean", "88 miles"],
+                    mute: ["timeout", "sleep"],
+                    commands: ["usage"],
+                    die: ["shutdown"],
+                    greet: ["welcome"],
+                });
 
                 // TODO: Do not show dev-only commands to mods, split to separate dev menu?
                 const outputs = [

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,21 @@
 import Client from "chatexchange";
 import dotenv from "dotenv";
 import entities from 'html-entities';
-import { AccessLevel, CommandManager } from './commands.js';
+import { setAccessCommand } from "./commands/commands.js";
+import { AccessLevel, CommandManager } from './commands/index.js';
 import Election from './election.js';
 import {
-    isAskedAboutVoting,
+    isAskedAboutModsOrModPowers, isAskedAboutUsernameDiamond, isAskedAboutVoting,
     isAskedForCandidateScore, isAskedForCurrentMods,
     isAskedForCurrentNominees, isAskedForCurrentWinners,
-    isAskedForElectionSchedule, 
-    isAskedAboutModsOrModPowers, isAskedIfModsArePaid,
-    isAskedWhyNominationRemoved, 
-    isAskedAboutUsernameDiamond,
+    isAskedForElectionSchedule, isAskedIfModsArePaid,
+    isAskedWhyNominationRemoved
 } from "./guards.js";
 import {
-    sayAboutVoting,
-    sayCandidateScoreFormula, sayCurrentMods,
-    sayCurrentWinners, 
-    sayElectionSchedule, 
-    sayWhatModsDo, sayAreModsPaid, 
-    sayHI, sayWhatIsAnElection,
-    sayInformedDecision, 
-    sayNotStartedYet, 
-    sayNextPhase, sayElectionIsOver, 
-    sayRequiredBadges, sayBadgesByType, 
-    sayWhyNominationRemoved,
-    sayOffTopicMessage
+    sayAboutVoting, sayAreModsPaid, sayBadgesByType, sayCandidateScoreFormula, sayCurrentMods,
+    sayCurrentWinners, sayElectionIsOver, sayElectionSchedule, sayHI, sayInformedDecision, sayNextPhase, sayNotStartedYet, sayOffTopicMessage, sayRequiredBadges, sayWhatIsAnElection, sayWhatModsDo, sayWhyNominationRemoved
 } from "./messages.js";
-import { getRandomPlop, getRandomGoodThanks, RandomArray } from "./random.js";
+import { getRandomGoodThanks, getRandomPlop, RandomArray } from "./random.js";
 import Announcement from './ScheduledAnnouncement.js';
 import { makeCandidateScoreCalc } from "./score.js";
 import {

--- a/src/index.js
+++ b/src/index.js
@@ -512,6 +512,8 @@ const announcement = new Announcement();
                     return `Brewing some ${coffee.getRandom()} for ${name || "somebody"}`;
                 }, AccessLevel.privileged);
 
+                commander.add("access", "sets user's access level", setAccessCommand, AccessLevel.dev);
+
                 commander.add("timetravel", "sends bot back in time to another phase", (election, content) => {
                     const [, yyyy, MM, dd, today] = /(?:(\d{4})-(\d{2})-(\d{2}))|(today)/.exec(content) || [];
 
@@ -575,7 +577,8 @@ const announcement = new Announcement();
                     ["mute", /mute|timeout|sleep/, BotConfig, content, BotConfig.throttleSecs],
                     ["debug", /debug(?:ing)?/, BotConfig, content],
                     ["die", /die|shutdown|turn off/],
-                    ["greet", /^(greet|welcome)/, room, election]
+                    ["greet", /^(greet|welcome)/, room, election],
+                    ["access", /set (?:access|level)/, BotConfig, user, content]
                 ];
 
                 responseText = outputs.reduce(

--- a/src/index.js
+++ b/src/index.js
@@ -567,7 +567,7 @@ const announcement = new Announcement();
                     ["debug", /debug(?:ing)?/, BotConfig, content],
                     ["die", /die|shutdown|turn off/],
                     ["greet", /^(greet|welcome)/, room, election],
-                    ["access", /set (?:access|level)/, BotConfig, user, content]
+                    ["set access", /set (?:access|level)/, BotConfig, user, content]
                 ];
 
                 responseText = outputs.reduce(

--- a/test/commands.js
+++ b/test/commands.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { AccessLevel, CommandManager } from "../src/commands.js";
+import { AccessLevel, CommandManager } from "../src/commands/index.js";
 
 describe('Commander', () => {
 
@@ -19,12 +19,12 @@ describe('Commander', () => {
         return Object.assign(defaults, overrides);
     };
 
-    describe('aliases', () => {
-        const commander = new CommandManager(getMockUser());
-        commander.add("bark", "barks, what else?", () => "bark!");
-        commander.alias("bark", ["say"]);
+    describe('aliasing', () => {
+        it('"alias" should correctly add aliases', () => {
+            const commander = new CommandManager(getMockUser());
+            commander.add("bark", "barks, what else?", () => "bark!", AccessLevel.all);
+            commander.alias("bark", ["say"]);
 
-        it('should correctly add aliases', () => {
             expect(commander.commands.bark.aliases).length(1);
             expect(commander.commands.say.aliasFor).to.not.be.null;
         });
@@ -48,8 +48,38 @@ describe('Commander', () => {
             expect(commands.gold.aliases.map((a) => a.name)).to.deep.equal(goldAliases);
             expect(commands["♦"].aliases.map((a) => a.name)).to.deep.equal(diamondAliases);
         });
+    });
+
+
+    describe('help', () => {
+
+        it('should only list available commands', () => {
+
+            const commander = new CommandManager(getMockUser({
+                access: AccessLevel.user
+            }));
+            commander.add("alive", "pings the bot", () => "I am alive", AccessLevel.all);
+            commander.add("stop", "stops the bot", () => "stopping...", AccessLevel.dev);
+
+            const aliveRegex = /\[alive\] pings the bot/;
+            const stopRegex = /\[stop\] stops the bot/;
+
+            const userHelp = commander.help();
+            expect(userHelp).to.match(aliveRegex);
+            expect(userHelp).to.not.match(stopRegex);
+
+            commander.user.access = AccessLevel.dev;
+
+            const devHelp = commander.help();
+            expect(devHelp).to.match(aliveRegex);
+            expect(devHelp).to.match(stopRegex);
+        });
 
         it('should correctly list aliases', () => {
+            const commander = new CommandManager(getMockUser());
+            commander.add("bark", "barks, what else?", () => "bark!", AccessLevel.all);
+            commander.alias("bark", ["say"]);
+
             const help = commander.help();
             expect(help).to.equal(`Commands\n- [bark] (say) barks, what else?`);
         });

--- a/test/commands.js
+++ b/test/commands.js
@@ -29,6 +29,26 @@ describe('Commander', () => {
             expect(commander.commands.say.aliasFor).to.not.be.null;
         });
 
+        it('"aliases" method should correct set aliases', () => {
+
+            const commander = new CommandManager(getMockUser());
+            commander.add("♦", "gets a diamond", () => "♦");
+            commander.add("gold", "gets some gold", () => "#FFD700");
+
+            const goldAliases = ["aurum"];
+            const diamondAliases = ["diamond", "mod"];
+
+            commander.aliases({
+                "♦": diamondAliases,
+                "gold": goldAliases
+            });
+
+            const { commands } = commander;
+
+            expect(commands.gold.aliases.map((a) => a.name)).to.deep.equal(goldAliases);
+            expect(commands["♦"].aliases.map((a) => a.name)).to.deep.equal(diamondAliases);
+        });
+
         it('should correctly list aliases', () => {
             const help = commander.help();
             expect(help).to.equal(`Commands\n- [bark] (say) barks, what else?`);


### PR DESCRIPTION
This PR includes several improvements to command-related functionality:

- adds access level filtering (devs see all commands, admins - only up to their level, others - none of them [as we do not have unprivileged commands], the bot responds with the list of topics as expected)
- adds a convenience method for command aliasing (`aliases`) that accept an alias dictionary
- adds a `set access` command (signature: `set access <id|"me"> <user|admin|dev>`) dev-only command (helps test privilege de-elevation)
- moves command callbacks (for now, only the `set access`'s one as a pilot) to a separate module to make commands more maintainable and be able to add JSDoc for each of them
- some minor improvements/fixes (can be found in the commit list)

Also addresses #66 except for not showing dev commands during election - we might want to split the issue before merging if everything looks good, as the PR will auto-close it.