### PR TITLE
Switching to package parsing for contributor list; minor command-related updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,15 @@
     "dev": "babel-node src/index.js",
     "test": "mocha"
   },
-  "author": "Samuel Liew",
+  "author": {
+    "name": "Samuel Liew",
+    "url": "https://so-user.com/584192?tab=profile"
+  },
   "contributors": [
-    "Oleg Valter"
+    {
+      "name": "Oleg Valter",
+      "url": "https://stackoverflow.com/users/11407695"
+    }
   ],
   "license": "MIT",
   "repository": {

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,5 +1,5 @@
-import Election from "../election";
-import { dateToUtcTimestamp } from "../utils";
+import Election from "../election.js";
+import { dateToUtcTimestamp } from "../utils.js";
 
 /**
  * @typedef {import("../index").BotConfig} BotConfig

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,3 +1,5 @@
+import Election from "../election";
+
 /**
  * @summary changes user access level (can only de-elevate)
  * @param {import("../index").BotConfig} config bot config
@@ -30,4 +32,38 @@ export const setAccessCommand = (config, user, content) => {
     changeMap[level]?.();
 
     return `Changed access level of ${uid} to ${level}`;
+};
+
+/**
+ * @summary changes internal bot clock to a given day
+ * @param {Election} election current election instance
+ * @param {string} content incoming message content
+ * @returns {string}
+ */
+export const timetravelCommand = (election, content) => {
+    const [, yyyy, MM, dd, today] = /(?:(\d{4})-(\d{2})-(\d{2}))|(today)/.exec(content) || [];
+
+    if (!today && (!yyyy || !MM || !dd)) return "Sorry, Doc! Invalid coordinates";
+
+    const destination = today ? new Date() : new Date(+yyyy, +MM - 1, +dd);
+
+    const phase = Election.getPhase(election, destination);
+
+    election.phase = phase;
+
+    const intl = new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "2-digit",
+        hour12: true,
+        hour: "2-digit",
+        minute: "2-digit"
+    });
+
+    const arrived = intl
+        .format(destination)
+        .replace(/, /g, " ")
+        .replace(/ (?:AM|PM)$/, "");
+
+    return `Arrived at ${arrived}, today's phase: ${phase || "no phase"}`;
 };

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,4 +1,5 @@
 import Election from "../election";
+import { dateToUtcTimestamp } from "../utils";
 
 /**
  * @typedef {import("../index").BotConfig} BotConfig
@@ -90,4 +91,20 @@ export const setThrottleCommand = (content, config) => {
     }
 
     return `*invalid throttle value*`;
+};
+
+/**
+ * @summary pings the bot for uptime
+ * @param {string} host bot host name
+ * @param {Date} start election start date
+ * @param {BotConfig} config bot config
+ * @returns {string}
+ */
+export const isAliveCommand = (host, start, config) => {
+
+    const hosted = `I'm alive on ${host || "planet Earth"}`;
+    const started = `started on ${dateToUtcTimestamp(start)}`;
+    const uptime = `uptime of ${Math.floor((Date.now() - start.getTime()) / 1e3)} seconds`;
+
+    return `${hosted}, ${started} with an ${uptime}.${config.debug ? ' I am in debug mode.' : ''}`;
 };

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,8 +1,12 @@
 import Election from "../election";
 
 /**
+ * @typedef {import("../index").BotConfig} BotConfig
+ */
+
+/**
  * @summary changes user access level (can only de-elevate)
- * @param {import("../index").BotConfig} config bot config
+ * @param {BotConfig} config bot config
  * @param {import("../index").User} user message author
  * @param {string} content incoming message content
  * @returns {string}
@@ -66,4 +70,24 @@ export const timetravelCommand = (election, content) => {
         .replace(/ (?:AM|PM)$/, "");
 
     return `Arrived at ${arrived}, today's phase: ${phase || "no phase"}`;
+};
+
+/**
+ * @summary sets message throttle (in seconds)
+ * @param {string} content incoming message content
+ * @param {BotConfig} config bot config
+ * @returns {string}
+ */
+export const setThrottleCommand = (content, config) => {
+    const [match] = content.match(/(?:\d+\.)?\d+$/) || [];
+    const newThrottle = +match;
+
+    const isValidThrottle = !isNaN(newThrottle) && newThrottle >= 0;
+
+    if (isValidThrottle) {
+        config.throttleSecs = newThrottle;
+        return `*throttle set to ${newThrottle} seconds*`;
+    }
+
+    return `*invalid throttle value*`;
 };

--- a/src/guards.js
+++ b/src/guards.js
@@ -26,8 +26,8 @@ export const isAskedIfModsArePaid = (text) => {
  * @returns {boolean}
  */
 export const isAskedAboutModsOrModPowers = (text) => {
-    return /^(?:why|what|should|does)\b/.test(text) && 
-        /\b(?:should i (?:be|become)|is a|(?:do|does)(?: a)? (?:mod|moderator)s?|benefits?|privileges?|powers?|responsibilit(?:y|ies))\b/.test(text) && 
+    return /^(?:why|what|should|does)\b/.test(text) &&
+        /\b(?:should i (?:be|become)|is a|(?:do|does)(?: a)? (?:mod|moderator)s?|benefits?|privileges?|powers?|responsibilit(?:y|ies))\b/.test(text) &&
         /\b(?:mod|moderator)s?\b/.test(text);
 };
 
@@ -99,4 +99,13 @@ export const isAskedForElectionSchedule = (text) => {
  */
 export const isAskedAboutUsernameDiamond = (text) => {
     return /(?:edit|insert|add).+?(?:\u2666|diamond).+?(?:user)?name/.test(text);
+};
+
+/**
+ * @summary checks if the message asked who created or maintains the bot
+ * @param {string} text
+ * @returns {boolean}
+ */
+export const isAskedWhoMadeMe = (text) => {
+    return /who(?:\s+(?:are|is) your)?\s+(?:made|created|owns|develop(?:s|ed|ers?)|maintain(?:s|ers?))(\s+you)?/.test(text);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Client from "chatexchange";
 import dotenv from "dotenv";
 import entities from 'html-entities';
-import { setAccessCommand, timetravelCommand } from "./commands/commands.js";
+import { setAccessCommand, setThrottleCommand, timetravelCommand } from "./commands/commands.js";
 import { AccessLevel, CommandManager } from './commands/index.js';
 import Election from './election.js';
 import {
@@ -456,19 +456,7 @@ const announcement = new Announcement();
                     return `Reply throttle is currently ${throttle} seconds. Use \`set throttle X\` (seconds) to set a new value.`;
                 }, AccessLevel.privileged);
 
-                commander.add("set throttle", "sets throttle to N (in seconds)", (content, config) => {
-                    const [match] = content.match(/(?:\d+\.)?\d+$/) || [];
-                    const newThrottle = +match;
-
-                    const isValidThrottle = !isNaN(newThrottle) && newThrottle >= 0;
-
-                    if (isValidThrottle) {
-                        config.throttleSecs = newThrottle;
-                        return `*throttle set to ${newThrottle} seconds*`;
-                    }
-
-                    return `*invalid throttle value*`;
-                }, AccessLevel.privileged);
+                commander.add("set throttle", "sets throttle to N (in seconds)", setThrottleCommand, AccessLevel.privileged);
 
                 commander.add("chatroom", "gets election chat room link", ({ chatUrl }) => {
                     return `The election chat room is at ${chatUrl || "the platform 9 3/4"}`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Client from "chatexchange";
 import dotenv from "dotenv";
 import entities from 'html-entities';
-import { setAccessCommand, setThrottleCommand, timetravelCommand } from "./commands/commands.js";
+import { isAliveCommand, setAccessCommand, setThrottleCommand, timetravelCommand } from "./commands/commands.js";
 import { AccessLevel, CommandManager } from './commands/index.js';
 import Election from './election.js';
 import {
@@ -428,14 +428,7 @@ const announcement = new Announcement();
 
                 commander.add("say", "bot echoes something", (content) => content.replace(/^@\S+\s+say /i, ''), AccessLevel.privileged);
 
-                commander.add("alive", "bot reports on its status", (host, start) => {
-
-                    const hosted = `I'm alive on ${host || "planet Earth"}`;
-                    const started = `started on ${dateToUtcTimestamp(start)}`;
-                    const uptime = `uptime of ${Math.floor((Date.now() - start.getTime()) / 1e3)} seconds`;
-
-                    return `${hosted}, ${started} with an ${uptime}.${BotConfig.debug ? ' I am in debug mode.' : ''}`;
-                }, AccessLevel.privileged);
+                commander.add("alive", "bot reports on its status", isAliveCommand, AccessLevel.privileged);
 
                 commander.add("debug", "switches debugging on/off", (config, content) => {
                     const [, state = "on"] = /(on|off)/.exec(content) || [];
@@ -515,7 +508,7 @@ const announcement = new Announcement();
                 const outputs = [
                     ["commands", /commands|usage/],
                     ["say", /say/, origContent],
-                    ["alive", /alive/, scriptHostname, scriptInitDate],
+                    ["alive", /alive/, scriptHostname, scriptInitDate, BotConfig],
                     ["test cron", /test cron/, announcement],
                     ["get cron", /get cron/, announcement],
                     ["get throttle", /get throttle/, BotConfig.throttleSecs],

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import {
 } from "./guards.js";
 import {
     sayAboutVoting, sayAreModsPaid, sayBadgesByType, sayCandidateScoreFormula, sayCurrentMods,
-    sayCurrentWinners, sayElectionIsOver, sayElectionSchedule, sayHI, sayInformedDecision, sayNextPhase, sayNotStartedYet, sayOffTopicMessage, sayRequiredBadges, sayWhatIsAnElection, sayWhatModsDo, sayWhyNominationRemoved
+    sayCurrentWinners, sayElectionIsOver, sayElectionSchedule, sayHI, sayInformedDecision, sayNextPhase, sayNotStartedYet, sayOffTopicMessage, sayRequiredBadges, sayWhatIsAnElection, sayWhatModsDo, sayWhoMadeMe, sayWhyNominationRemoved
 } from "./messages.js";
 import { getRandomGoodThanks, getRandomPlop, RandomArray } from "./random.js";
 import Announcement from './ScheduledAnnouncement.js';
@@ -595,7 +595,7 @@ const announcement = new Announcement();
                     responseText = `I'm ${me.name} and ${me.about}`;
                 }
                 else if (isAskedWhoMadeMe(content)) {
-                    responseText = `[Samuel](https://so-user.com/584192?tab=profile) created me. I am also maintained by [these developers](https://github.com/samliew/se-electionbot/graphs/contributors).`;
+                    responseText = await sayWhoMadeMe(BotConfig);
                 }
                 else if (content.startsWith(`i love you`)) {
                     responseText = `I love you 3000`;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import {
     isAskedForCandidateScore, isAskedForCurrentMods,
     isAskedForCurrentNominees, isAskedForCurrentWinners,
     isAskedForElectionSchedule, isAskedIfModsArePaid,
+    isAskedWhoMadeMe,
     isAskedWhyNominationRemoved
 } from "./guards.js";
 import {
@@ -593,7 +594,7 @@ const announcement = new Announcement();
                 else if (["about", "who are you?"].includes(content)) {
                     responseText = `I'm ${me.name} and ${me.about}`;
                 }
-                else if (content.includes('who') && ['made', 'created', 'owner', 'devs', 'developer'].some(x => content.includes(x)) && content.includes('you')) {
+                else if (isAskedWhoMadeMe(content)) {
                     responseText = `[Samuel](https://so-user.com/584192?tab=profile) created me. I am also maintained by [these developers](https://github.com/samliew/se-electionbot/graphs/contributors).`;
                 }
                 else if (content.startsWith(`i love you`)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Client from "chatexchange";
 import dotenv from "dotenv";
 import entities from 'html-entities';
-import { setAccessCommand } from "./commands/commands.js";
+import { setAccessCommand, timetravelCommand } from "./commands/commands.js";
 import { AccessLevel, CommandManager } from './commands/index.js';
 import Election from './election.js';
 import {
@@ -503,33 +503,7 @@ const announcement = new Announcement();
 
                 commander.add("set access", "sets user's access level", setAccessCommand, AccessLevel.dev);
 
-                commander.add("timetravel", "sends bot back in time to another phase", (election, content) => {
-                    const [, yyyy, MM, dd, today] = /(?:(\d{4})-(\d{2})-(\d{2}))|(today)/.exec(content) || [];
-
-                    if (!today && (!yyyy || !MM || !dd)) return "Sorry, Doc! Invalid coordinates";
-
-                    const destination = today ? new Date() : new Date(+yyyy, +MM - 1, +dd);
-
-                    const phase = Election.getPhase(election, destination);
-
-                    election.phase = phase;
-
-                    const intl = new Intl.DateTimeFormat("en-US", {
-                        year: "numeric",
-                        month: "short",
-                        day: "2-digit",
-                        hour12: true,
-                        hour: "2-digit",
-                        minute: "2-digit"
-                    });
-
-                    const arrived = intl
-                        .format(destination)
-                        .replace(/, /g, " ")
-                        .replace(/ (?:AM|PM)$/, "");
-
-                    return `Arrived at ${arrived}, today's phase: ${phase || "no phase"}`;
-                }, AccessLevel.dev);
+                commander.add("timetravel", "sends bot back in time to another phase", timetravelCommand, AccessLevel.dev);
 
                 // to reserve the keyword 'help' for normal users
                 commander.add("commands", "Prints usage info", () => commander.help("moderator commands (requires mention):"), AccessLevel.privileged);

--- a/src/index.js
+++ b/src/index.js
@@ -501,7 +501,7 @@ const announcement = new Announcement();
                     return `Brewing some ${coffee.getRandom()} for ${name || "somebody"}`;
                 }, AccessLevel.privileged);
 
-                commander.add("access", "sets user's access level", setAccessCommand, AccessLevel.dev);
+                commander.add("set access", "sets user's access level", setAccessCommand, AccessLevel.dev);
 
                 commander.add("timetravel", "sends bot back in time to another phase", (election, content) => {
                     const [, yyyy, MM, dd, today] = /(?:(\d{4})-(\d{2})-(\d{2}))|(today)/.exec(content) || [];

--- a/src/messages.js
+++ b/src/messages.js
@@ -3,9 +3,11 @@ import {
     capitalize, dateToRelativetime, linkToRelativeTimestamp,
     linkToUtcTimestamp, listify, makeURL, pluralize
 } from "./utils.js";
+import { parsePackage } from "./utils/package.js";
 
 /**
  * @typedef {import("./index").Badge} Badge
+ * @typedef {import("./index").BotConfig} BotConfig
  */
 
 /**
@@ -336,4 +338,25 @@ export const sayWhatIsAnElection = (election) => {
     const eligibility = `users with at least ${repVote} reputation can vote for them`;
 
     return `An ${electionURL} is where users nominate themselves as candidates for the role of ${diamondURL}, and ${eligibility}.`;
+};
+
+/**
+ * @summary builds a contributor list message
+ * @param {BotConfig} config
+ * @returns {Promise<string>}
+ */
+export const sayWhoMadeMe = async (config) => {
+    const info = await parsePackage("./package.json");
+    if (!info) {
+        if (config.debug) console.log("failed to parse bot package");
+        return `${makeURL("Samuel", "https://so-user.com/584192?tab=profile")} made me.`;
+    }
+
+    const { author, contributors } = info;
+
+    const created = `${makeURL(author.name, author.url)} created me`;
+    const contributed = listify(...contributors.map(({ name, url }) => makeURL(name, url)));
+    const maintainers = `I am also maintained by ${contributed}`;
+
+    return `${created}. ${maintainers}.`;
 };

--- a/src/utils/package.js
+++ b/src/utils/package.js
@@ -1,0 +1,68 @@
+import { readFile } from "fs/promises";
+
+/**
+ * @typedef {string | {
+ * name: string;
+ * email?: string;
+ * url?: string;
+ * }} PackagePerson
+ *
+ * @typedef {{
+ * author: PackagePerson;
+ * contributors?: PackagePerson[];
+ * icon?: string;
+ * license: string;
+ * homepage: string;
+ * keywords?: string[];
+ * name: string;
+ * version: `${number}.${number}.${number}` | `${number}.${number}`;
+ * description: string;
+ * bugs: { url: string; };
+ * repository: { type: "git" | "https"; url: string; };
+ * }} PackageInfo
+ *
+ */
+
+/**
+ * @summary parses person info from package.json
+ * @param {PackagePerson} info person info
+ * @returns {Exclude<PackagePerson,string>}
+ */
+export const parsePerson = (info) => {
+    if (typeof info === "object") return info;
+
+    const authorRegex = /(\w+(?:\s\w+)?)(?:\s<(.+?)>)?(?:\s\((.+?)\))?$/i;
+
+    const match = authorRegex.exec(info);
+
+    if (!match) throw new Error(`unable to parse author field: ${info}`);
+
+    const [_full, name, email, url] = match;
+
+    return {
+        name,
+        email,
+        url,
+    };
+};
+
+/**
+ * @summary reads and parses package content
+ * @param {string} path path to package.json
+ * @returns {Promise<PackageInfo|null>}
+ */
+export const parsePackage = async (path) => {
+    try {
+        const contents = await readFile(path, { encoding: "utf-8" });
+        const parsed = JSON.parse(contents);
+
+        return {
+            ...parsed,
+            author: parsePerson(parsed.author),
+            contributors: (parsed.contributors || []).map(parsePerson)
+        };
+
+    } catch (error) {
+        return null;
+    }
+};

--- a/src/utils/package.js
+++ b/src/utils/package.js
@@ -49,7 +49,10 @@ export const parsePerson = (info) => {
 /**
  * @summary reads and parses package content
  * @param {string} path path to package.json
- * @returns {Promise<PackageInfo|null>}
+ * @returns {Promise<(Omit<PackageInfo, "author"|"contributors"> & {
+ *  author: Exclude<PackagePerson,string>,
+ *  contributors: Exclude<PackagePerson,string>[]
+ * })|null>}
  */
 export const parsePackage = async (path) => {
     try {

--- a/test/guards.js
+++ b/test/guards.js
@@ -1,8 +1,7 @@
 import { expect } from "chai";
 import {
-    isAskedForElectionSchedule,
     isAskedAboutModsOrModPowers,
-    isAskedAboutUsernameDiamond
+    isAskedAboutUsernameDiamond, isAskedForElectionSchedule, isAskedWhoMadeMe
 } from "../src/guards.js";
 
 describe('Message Guards', () => {
@@ -64,6 +63,30 @@ describe('Message Guards', () => {
 
             matches.forEach((txt) => {
                 const matched = isAskedAboutUsernameDiamond(txt);
+                expect(matched, `<${txt}> not matched`).to.be.true;
+            });
+
+        });
+
+    });
+
+    describe('isAskedWhoMadeMe', () => {
+
+        it('should correctly match content', () => {
+
+            const matches = [
+                "who made you?",
+                "who maintains you?",
+                "who develops you?",
+                "who are your developers?",
+                "who developed you?",
+                "who owns you?",
+                "who is your developer?",
+                "who is your maintainer?"
+            ];
+
+            matches.forEach((txt) => {
+                const matched = isAskedWhoMadeMe(txt);
                 expect(matched, `<${txt}> not matched`).to.be.true;
             });
 

--- a/test/package.js
+++ b/test/package.js
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import { parsePackage, parsePerson } from "../src/utils/package.js";
+
+describe('Package Parsing', () => {
+    describe('parsePerson', () => {
+
+        it('should correctly parse person strings', () => {
+            const { name, email, url } = parsePerson("John Doe <john@doe.com> (https://example.com)");
+            expect(name).to.equal("John Doe");
+            expect(email).to.equal("john@doe.com");
+            expect(url).to.equal("https://example.com");
+        });
+
+        it('should correctly parse person objects', () => {
+            const info = { name: "John Doe", url: "https://example.com" };
+            const parsed = parsePerson(info);
+            expect(info).to.deep.equal(parsed);
+        });
+
+    });
+
+    describe('parsePackage', () => {
+
+        it('should correctly parse package.json info', async () => {
+            const { author, contributors } = await parsePackage("./package.json");
+            expect(author).to.deep.equal({
+                name: "Samuel Liew",
+                url: void 0,
+                email: void 0
+            });
+            expect(contributors).to.be.an.instanceOf(Array);
+        });
+
+        it('should return null on error', async () => {
+            const invalid = await parsePackage("");
+            expect(invalid).to.be.null;
+        });
+
+    });
+});

--- a/test/package.js
+++ b/test/package.js
@@ -25,8 +25,7 @@ describe('Package Parsing', () => {
             const { author, contributors } = await parsePackage("./package.json");
             expect(author).to.deep.equal({
                 name: "Samuel Liew",
-                url: void 0,
-                email: void 0
+                url: "https://so-user.com/584192?tab=profile",
             });
             expect(contributors).to.be.an.instanceOf(Array);
         });


### PR DESCRIPTION
The PR resolves #69 by switching to package.json parsing, as well as makes some utility updates to the bot:

- moves `set throttle`, `alive` , and `throttle` commands to the dedicated module (+adds JSDoc docs for them)
- fixes `set throttle` command missing the `set` prefix (my bad - I forgot to commit that :( for the last PR)
- adds message guard for the "who made me" question (and expands on the list of matching messages)
- adds message builder for the "who made me" message (+a default in case package parsing fails)

The bot responds to the "who made you?" (and its variations - can be found in tests) with pretty much the same message, except it simply lists contributors (each added contributor expands the list) with links to their profiles (can be anything put into the `url` field of the package.json contributor info):

```text
Samuel Liew created me. I am also maintained by <contributor1>, <contributor2>, and <contributorN>
```