### PR TITLE
Enhancement for the isActive method + unit tests

### DIFF
--- a/src/election.js
+++ b/src/election.js
@@ -45,9 +45,10 @@ export default class Election {
             this.dateEnded
         );
     }
-    
+
     /**
      * @summary checks if the electionUrl is valid
+     * @param {string} electionUrl election URL to test
      * @returns {boolean}
      */
     validElectionUrl(electionUrl) {
@@ -59,7 +60,8 @@ export default class Election {
      * @returns {boolean}
      */
     isActive() {
-        return this.phase !== null && this.phase !== "ended";
+        const { phase } = this;
+        return ![null, "ended", "cancelled"].includes(phase);
     }
 
     /**
@@ -141,7 +143,7 @@ export default class Election {
     async scrapeElection(config) {
 
         // Validate electionUrl, since without it we cannot continue
-        if(!this.validElectionUrl(this.electionUrl)) {
+        if (!this.validElectionUrl(this.electionUrl)) {
             console.error("Invalid electionUrl format.");
             return;
         }
@@ -208,13 +210,13 @@ export default class Election {
             this.phase = Election.getPhase(this);
 
             // Detect active election number if not specified
-            if(this.isActive() && this.electionNum === null) {
+            if (this.isActive() && this.electionNum === null) {
                 this.electionNum = +metaPhaseElems.attr('href').match(/\d+/)?.pop() || null;
 
                 // Append to electionUrl
                 this.electionUrl += `/${this.electionNum}`;
 
-                if(config.verbose) console.log('INFO  - Election number was auto-detected', this.electionNum);
+                if (config.verbose) console.log('INFO  - Election number was auto-detected', this.electionNum);
             }
 
             // If election has ended (or cancelled)

--- a/test/unit/election.js
+++ b/test/unit/election.js
@@ -68,4 +68,29 @@ describe('Election', () => {
 
     });
 
+    describe('isActive', () => {
+
+        it('should correctly determine active state', () => {
+
+            const election = new Election("https://stackoverflow.com/election/12");
+
+            const inactivePhases = [null, "ended", "cancelled"];
+            const activePhases = ["election", "primary", "nomination"];
+
+            const allInactive = inactivePhases.every((phase) => {
+                election.phase = phase;
+                return !election.isActive();
+            });
+
+            const allActive = activePhases.every((phase) => {
+                election.phase = phase;
+                return election.isActive();
+            });
+
+            expect(allActive).to.be.true;
+            expect(allInactive).to.be.true;
+        });
+
+    });
+
 });


### PR DESCRIPTION
This is a very small PR making sure `cancelled` elections are not marked as active. Plus it covers the method with a unit test for all possible election states.