### PR TITLE
Making RandomArray and responseText strictly typed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -532,6 +532,7 @@ import {
 
             // Mentioned bot (8)
             if (config.throttleSecs <= 10 && eventType === ChatEventType.USER_MENTIONED && targetUserId === me.id) {
+                /** @type {string | null} */
                 let responseText = null;
 
                 if (content.startsWith('offtopic')) {
@@ -637,6 +638,7 @@ import {
 
             // Any new message that does not reply-to or mention any user (1)
             else if (eventType === ChatEventType.MESSAGE_POSTED && !targetUserId) {
+                /** @type {string | null} */
                 let responseText = null;
 
                 // Moderation badges
@@ -709,7 +711,7 @@ import {
 
                 // Election stats - How many voted/participants/participated
                 else if (['how', 'many'].every(x => content.includes(x)) && ['voters', 'voted', 'participated', 'participants'].some(x => content.includes(x))) {
-                    responseText = election.phase == 'ended' ? election.statVoters : `We won't know until the election ends. Come back ${linkToRelativeTimestamp(election.dateEnded)}.`;
+                    responseText = election.phase == 'ended' ? (election.statVoters || null) : `We won't know until the election ends. Come back ${linkToRelativeTimestamp(election.dateEnded)}.`;
                 }
 
                 // How to choose/pick/decide/determine who to vote for
@@ -725,7 +727,7 @@ import {
                         responseText = `${user.name} is the best mod!!!`;
                     }
                     else {
-                        responseText = new RandomArray(currModNames.map(name => `${getRandomSecret()} ${name} is the best mod!`)).getRandom();
+                        responseText = new RandomArray(...currModNames.map(name => `${getRandomSecret()} ${name} is the best mod!`)).getRandom();
                     }
                 }
 
@@ -769,7 +771,7 @@ import {
                         responseText = sayElectionIsOver(election);
                     }
                     else if (election.phase === 'cancelled') {
-                        responseText = election.statVoters;
+                        responseText = election.statVoters || null;
                     }
                     else if (election.phase === 'election') {
                         responseText = `The [election](${election.electionUrl}?tab=election) is in the final voting phase. `;

--- a/src/queue.js
+++ b/src/queue.js
@@ -11,7 +11,7 @@ import { wait } from "./utils.js";
  * @description private function to actually send the message, so we can apply throttle and queue messages
  * @param {BotConfig} config bot configuration
  * @param {Room} room room to announce in
- * @param {string} responseText Message to send
+ * @param {null|string} responseText Message to send
  * @param {null|number} inResponseTo message ID to reply to
  * @returns {Promise<any>}
  */
@@ -46,7 +46,7 @@ const _sendTheMessage = async function (config, room, responseText, inResponseTo
  *
  * @param {BotConfig} config bot configuration
  * @param {Room} room room to announce in
- * @param {string} responseText Message to send
+ * @param {null|string} responseText Message to send
  * @param {null|number} [inResponseTo] message ID to reply to
  * @param {boolean} [isPrivileged] privileged user flag
  * @returns {Promise<any>}
@@ -60,7 +60,7 @@ export const sendMessage = async function (config, room, responseText, inRespons
  *
  * @param {BotConfig} config bot configuration
  * @param {Room} room room to announce in
- * @param {string} responseText Message to send
+ * @param {null|string} responseText Message to send
  * @param {number} inResponseTo message ID to reply to
  * @param {boolean} [isPrivileged] privileged user flag
  * @returns {Promise<any>}

--- a/src/random.js
+++ b/src/random.js
@@ -1,6 +1,9 @@
+/**
+ * @template {unknown} T
+ */
 export class RandomArray extends Array {
     /**
-     * @param {...any} init
+     * @param {...T} init
      */
     constructor(...init) {
         super(...init);
@@ -8,7 +11,7 @@ export class RandomArray extends Array {
 
     /**
      * @summary gets a random element
-     * @returns {any}
+     * @returns {T}
      */
     getRandom() {
         const rnd = Math.floor(Math.random() * this.length);
@@ -17,7 +20,7 @@ export class RandomArray extends Array {
 
     /**
      * @summary sorts in random order
-     * @returns {RandomArray}
+     * @returns {RandomArray<T>}
      */
     sortByRandom() {
         // https://stackoverflow.com/a/46545530


### PR DESCRIPTION
This PR ensures `responseText` cannot be anything but of the expected value type (`string | null`)