### PR TITLE
Replace the "breaking news" message with a less urgent-sounding one

### DIFF
--- a/src/rescraper.js
+++ b/src/rescraper.js
@@ -180,7 +180,7 @@ export default class Rescraper {
                 console.log(`RESCRAPER - Room is inactive with ${config.activityCounter} messages posted so far (min ${config.minActivityCountThreshold}).`);
 
                 const greetings = new RandomArray(...[
-                    "Breaking news!!! ",
+                    "Public service announcement: ",
                     "I'm sorry to say this, but... ",
                     "A quick message from my sponsors: ",
                     "Welcome to the election chat room! ",


### PR DESCRIPTION
The previous message had confused people into thinking there was
election-related news.  This replaces the message with the less
urgent-sounding "Public service announcement: ".
