### PR TITLE
Clearer "I'm sorry to..." message for the periodic greeting

### DIFF
--- a/src/random.js
+++ b/src/random.js
@@ -112,9 +112,13 @@ export const getRandomJonSkeetJoke = () => new RandomArray(
     `Users don't mark Jon Skeet's answers as accepted. The universe accepts them out of a sense of truth and justice.`,
 ).getRandom();
 
+export const getRandomInterjectionVerb = () => new RandomArray(
+    "interject", "interrupt", "interfere"
+).getRandom();
+
 export const getRandomAnnouncement = () => new RandomArray(
     "Public service announcement: ",
-    "I'm sorry to interject, but... ",
+    `I'm sorry to ${getRandomInterjectionVerb()}, but... `,
     "A quick message from my sponsors: ",
     "Welcome to the election chat room! ",
     "And now for something completely different - ",


### PR DESCRIPTION
In the RPG election chat, a user was briefly confused by the apology:
https://chat.stackexchange.com/transcript/message/59418819

This changes the message to one that is clearer that it's not related to
anything in particular that happened.
