### PR TITLE
Election announcements

### DIFF
--- a/src/bot/election.js
+++ b/src/bot/election.js
@@ -590,6 +590,9 @@ export default class Election {
     /** @type {Map<number, Election>} */
     elections = new Map();
 
+    /** @type {Map<number, ElectionAnnouncement>} */
+    announcements = new Map();
+
     /** @type {ElectionPhase|null} */
     phase = null;
 

--- a/src/bot/election.js
+++ b/src/bot/election.js
@@ -342,7 +342,7 @@ const announcementsCache = new Map();
  * @param {number} [page] feed page to scrape
  * @returns {Promise<Map<string, Map<number, ElectionAnnouncement>>>}
  */
-export const scrapeUpcomingElections = async (config, page = 1) => {
+export const scrapeElectionAnnouncements = async (config, page = 1) => {
     const url = new URL("https://stackexchange.com/filters/421979/all-elections");
     url.searchParams.append("page", page.toString());
 
@@ -433,7 +433,7 @@ export const scrapeUpcomingElections = async (config, page = 1) => {
     if (hasMore) {
         const nextPage = page + 1;
         console.log(`[announcements] scraping next page (${nextPage})`);
-        await scrapeUpcomingElections(config, nextPage);
+        await scrapeElectionAnnouncements(config, nextPage);
     }
 
     return announcementsCache;

--- a/src/bot/election.js
+++ b/src/bot/election.js
@@ -363,8 +363,8 @@ export const scrapeElectionAnnouncements = async (config, page = 1) => {
     // https://regex101.com/r/OTlwms/1
     const announcementTitleExpr = /^announc(?:ing|ement).+?election.+?for/i;
 
-    // https://regex101.com/r/xKRRih/1
-    const electionDateExpr = /on\s+(\d{1,2}\s+\w+|\w+\s+\d{1,2})(?:,?\s+(\d{2,4}))?$/i;
+    // https://regex101.com/r/uXY3xB/1
+    const electionDateExpr = /on\s+(\d{1,2}\s+\w+|\w+\s+\d{1,2})(?:,?\s+(\d{2,4}))?/i;
 
     const containers = questionList.querySelectorAll(".question-container");
 

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -11,7 +11,7 @@ import { CommandManager } from './commands/index.js';
 import { User } from "./commands/user.js";
 import BotConfig from "./config.js";
 import { joinControlRoom } from "./control/index.js";
-import { addWithdrawnNomineesFromChat, findNominationAnnouncementsInChat, getSiteElections, scrapeUpcomingElections } from './election.js';
+import { addWithdrawnNomineesFromChat, findNominationAnnouncementsInChat, getSiteElections, scrapeElectionAnnouncements } from './election.js';
 import {
     isAskedAboutBadgesOfType,
     isAskedAboutBallotFile,
@@ -224,7 +224,7 @@ import { getOrInit, sortMap } from "./utils/maps.js";
             return;
         }
 
-        const electionAnnouncements = await scrapeUpcomingElections(config);
+        const electionAnnouncements = await scrapeElectionAnnouncements(config);
         const electionSiteAnnouncements = getOrInit(electionAnnouncements, election.siteHostname, new Map());
         election.announcements = sortMap(electionSiteAnnouncements, (_, a, __, b) => b.dateElection > a.dateElection ? -1 : 1);
 

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -11,7 +11,7 @@ import { CommandManager } from './commands/index.js';
 import { User } from "./commands/user.js";
 import BotConfig from "./config.js";
 import { joinControlRoom } from "./control/index.js";
-import { addWithdrawnNomineesFromChat, findNominationAnnouncementsInChat, getSiteElections } from './election.js';
+import { addWithdrawnNomineesFromChat, findNominationAnnouncementsInChat, getSiteElections, scrapeUpcomingElections } from './election.js';
 import {
     isAskedAboutBadgesOfType,
     isAskedAboutBallotFile,
@@ -62,6 +62,7 @@ import {
 import { logActivity, logResponse } from "./utils/bot.js";
 import { prepareMessageForMatching } from "./utils/chat.js";
 import { matchNumber } from "./utils/expressions.js";
+import { getOrInit } from "./utils/maps.js";
 
 /**
  * @typedef {import("chatexchange/dist/User").default} ChatUser
@@ -222,6 +223,9 @@ import { matchNumber } from "./utils/expressions.js";
                 }`);
             return;
         }
+
+        const electionAnnouncements = await scrapeUpcomingElections(config);
+        election.announcements = getOrInit(electionAnnouncements, election.siteHostname, new Map());
 
         election.elections = elections;
 

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -62,7 +62,7 @@ import {
 import { logActivity, logResponse } from "./utils/bot.js";
 import { prepareMessageForMatching } from "./utils/chat.js";
 import { matchNumber } from "./utils/expressions.js";
-import { getOrInit } from "./utils/maps.js";
+import { getOrInit, sortMap } from "./utils/maps.js";
 
 /**
  * @typedef {import("chatexchange/dist/User").default} ChatUser
@@ -225,7 +225,8 @@ import { getOrInit } from "./utils/maps.js";
         }
 
         const electionAnnouncements = await scrapeUpcomingElections(config);
-        election.announcements = getOrInit(electionAnnouncements, election.siteHostname, new Map());
+        const electionSiteAnnouncements = getOrInit(electionAnnouncements, election.siteHostname, new Map());
+        election.announcements = sortMap(electionSiteAnnouncements, (_, a, __, b) => b.dateElection > a.dateElection ? -1 : 1);
 
         election.elections = elections;
 

--- a/src/server/views/index.handlebars
+++ b/src/server/views/index.handlebars
@@ -58,6 +58,32 @@
                 <tr><td>BLT file URL</td><td>{{{url (getter this "electionBallotURL")}}}</td></tr>
             </table>
 
+            <h2>Election Announcements</h2>
+            {{#if (len announcements)}}
+            <table class="table-small">
+                <thead>
+                    <tr>
+                        <th>Announced On</th>
+                        <th>Election Date</th>
+                        <th>Title</th>
+                        <th>Author</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{#each (values announcements)}}
+                    <tr>
+                        <td>{{utcTimestamp dateAnnounced}} <span class="relativetime" title="{{utcTimestamp dateAnnounced}}"></span></td>
+                        <td>{{utcTimestamp dateElection}} <span class="relativetime" title="{{utcTimestamp dateElection}}"></span></td>
+                        <td>{{{url postLink postTitle}}}</td>
+                        <td>{{{url userLink userName}}}</td>
+                    </tr>
+                    {{/each}}
+                </tbody>
+            </table>
+            {{else}}
+                {{> emptySmallTable }}
+            {{/if}}
+
             <h2>Candidates <span class="small-count" data-prefix="(" data-suffix=")">{{len nominees}} total, {{len @root/data/nomineesInRoom}} in the room</span></h2>
             {{#if (len nominees)}}
                 {{> nominees (values nominees) }}


### PR DESCRIPTION
This PR introduces:

- election announcements scraping (using https://stackexchange.com/filters/421979/all-elections)
- corresponding `announcements` instance property on the `Election` class
- new table for the `index` view with announcement info

The scraper is self-caching, and stores announcement data in a `Map` keyed on site hostname.
Each value is in itself a `Map` keyed on announcement post id.

The `announcements` property keys and values are sorted on date of the election.

Here is an example of the table:

![Example announcements table with one row for a pro tempore election](https://user-images.githubusercontent.com/34833340/165242680-533ea279-dc6b-45ca-8b18-cc707459e5f3.png)