### PR TITLE
Fix error with canddiate score message

### DIFF
--- a/src/bot/messages/score.js
+++ b/src/bot/messages/score.js
@@ -97,5 +97,5 @@ export const sayHasMaximumCandidateScore = (election, candidateScore, hasNominat
  * @returns {string}
  */
 export const sayNoAccountToCalcScore = (isAskingForOtherUser) => {
-    return `${getRandomOops()} ${isAskingForOtherUser ? "the user" : "you"} must have an account on the site to get the score!`;
+    return `${getRandomOops()} ${isAskingForOtherUser ? "the user" : "you"} must have sufficient rep on the site to get the score!`;
 };


### PR DESCRIPTION
This example: https://chat.stackexchange.com/transcript/message/63092686#63092686 shows that the bot was implying that I don't have an account, when really the problem was that I didn't have enough rep.

I changed "you must have an account to get a candidate score" to "you must have sufficient rep to get a candidate score".

